### PR TITLE
 	Use a SPARQL update to infer that in this context a resource with a SKOS label must be a skos:Concept.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <version>2.7.2</version>
+            <artifactId>jena-arq</artifactId>
+            <version>2.9.2</version>
             <type>jar</type>
             <scope>compile</scope>
             <exclusions>


### PR DESCRIPTION
when indexing a SKOS vocabulary i noticed that in some cases, concepts were being ignored because they are missing rdf:type skos:Concept. My idea here is to use any resource that has a skos:prefLabel property to overcome this problem. 
