### PR TITLE
Some enhancement proposals for the module with Solr 5.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 *.jar
 *.war
 *.ear
+build/

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <prerequisites>
+        <maven>3.0.1</maven>
+    </prerequisites>
+    
     <groupId>at.ac.univie.mminf</groupId>
     <artifactId>lucene-skos</artifactId>
     <packaging>jar</packaging>
@@ -109,8 +113,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>${maven.compiler.target}</source>
+                    <target>${maven.compiler.target}</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -178,33 +182,87 @@
                   </filesets>
                 </configuration>                
             </plugin>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <version>2.0</version>
+                <configuration>
+                    <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                    <internalRuntimeForbidden>true</internalRuntimeForbidden>
+                    <!--
+                      if the used Java version is too new,
+                      don't fail, just do nothing:
+                    -->
+                    <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                    <bundledSignatures>
+                        <!--
+                          This will automatically choose the right
+                          signatures based on 'maven.compiler.target':
+                        -->
+                        <bundledSignature>jdk-unsafe</bundledSignature>
+                        <bundledSignature>jdk-deprecated</bundledSignature>
+                        <bundledSignature>jdk-system-out</bundledSignature>
+                        <bundledSignature>commons-io-unsafe-2.4</bundledSignature>
+                    </bundledSignatures>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>testCheck</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+	
+ 	<profiles>
+	   <profile>
+		  <id>jouve</id>
+		  <distributionManagement>
+			<!-- use the following if you're not using a snapshot version. -->
+			<repository>
+			  <id>jouve-releases</id>
+			  <url>http://nexus-master-si.jouve.local/nexus/content/repositories/releases</url>
+			</repository>
+			<!-- use the following if you ARE using a snapshot version. -->
+			<snapshotRepository>
+			  <id>jouve-snapshots</id>
+			  <url>http://nexus-master-si.jouve.local/nexus/content/repositories/snapshots</url>
+			</snapshotRepository>
+		  </distributionManagement>
+		</profile>
+		
+		<profile>
+		  <id>apache</id>
+			<repositories>
+				<repository>
+					<id>apache-repo-releases</id>
+					<url>https://repository.apache.org/content/repositories/releases/</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+				</repository>
+				<repository>
+					<id>apache-repo-snapshots</id>
+					<url>https://repository.apache.org/content/repositories/snapshots/</url>
+					<releases>
+						<enabled>false</enabled>
+					</releases>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</repository>
+			</repositories>      
+		 </profile>
+	 </profiles>
 
-    <repositories>
-        <repository>
-            <id>apache-repo-releases</id>
-            <url>https://repository.apache.org/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>apache-repo-snapshots</id>
-            <url>https://repository.apache.org/content/repositories/snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
+  
     <properties>
         <lucene.version>5.3.1</lucene.version>
         <jena.version>2.12.1</jena.version>
-        <java.version>1.7</java.version>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/AbstractSKOSFilter.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/AbstractSKOSFilter.java
@@ -16,14 +16,21 @@ package at.ac.univie.mminf.luceneSKOS.analysis;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngine;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute.SKOSType;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeSet;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.payloads.PayloadHelper;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.PayloadAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.util.AttributeSource;
@@ -31,152 +38,171 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.CharsRefBuilder;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeSet;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
 
 /**
- * A SKOS-specific TokenFilter implementation
+ * Basic methods for SKOS-specific TokenFilter implementations
  */
 public abstract class AbstractSKOSFilter extends TokenFilter {
 
-  /* a stack holding the expanded terms for a token */
-  protected Stack<ExpandedTerm> termStack;
-  /* an engine delivering SKOS concepts */
-  protected SKOSEngine engine;
-  /* the skos types to expand to */
-  protected Set<SKOSType> types;
-  /* provides access to the the term attributes */
-  protected AttributeSource.State current;
-  /* the term text (propagated to the index) */
-  protected final CharTermAttribute termAtt;
-  /* the token position relative to the previous token (propagated) */
-  protected final PositionIncrementAttribute posIncrAtt;
-  /* the binary payload attached to the indexed term (propagated to the index) */
-  protected final PayloadAttribute payloadAtt;
-  /* the SKOS-specific attribute attached to a term */
-  protected final SKOSTypeAttribute skosAtt;
-  /* the analyzer to use when parsing */
-  protected final Analyzer analyzer;
+    // a stack holding the expanded terms for a token
+    protected Stack<ExpandedTerm> termStack;
+    // an engine delivering SKOS concepts
+    protected SKOSEngine engine;
+    // the skos types to expand to
+    protected Set<SKOSType> types;
+    // provides access to the the term attributes
+    protected AttributeSource.State current;
+    // the term text (propagated to the index)
+    protected final CharTermAttribute termAtt;
+    // the token position relative to the previous token (propagated)
+    protected final OffsetAttribute offsettAtt;
+    // the token position relative to the previous token (propagated)
 
-  /**
-   * Constructor
-   *
-   * @param input    the TokenStream
-   * @param engine   the engine delivering skos concepts
-   * @param analyzer the analyzer
-   * @param types    the skos types to expand to
-   */
-  public AbstractSKOSFilter(TokenStream input, SKOSEngine engine,
-                            Analyzer analyzer, SKOSType... types) {
-    super(input);
-    termStack = new Stack<>();
-    this.engine = engine;
-    this.analyzer = analyzer;
-    if (types != null && types.length > 0) {
-      this.types = new TreeSet<>(Arrays.asList(types));
-    } else {
-      this.types = new TreeSet<>(Arrays.asList(new SKOSType[]{
-          SKOSType.PREF, SKOSType.ALT}));
-    }
-    this.termAtt = addAttribute(CharTermAttribute.class);
-    this.posIncrAtt = addAttribute(PositionIncrementAttribute.class);
-    this.payloadAtt = addAttribute(PayloadAttribute.class);
-    this.skosAtt = addAttribute(SKOSTypeAttribute.class);
-  }
+    protected final PositionIncrementAttribute posIncrAtt;
+    // the binary payload attached to the indexed term (propagated to the index)
+    protected final PayloadAttribute payloadAtt;
+    // the SKOS-specific attribute attached to a term
+    protected final SKOSTypeAttribute skosAtt;
+    // the analyzer to use when parsing
+    protected final Analyzer analyzer;
 
-  /**
-   * Advances the stream to the next token.
-   * <p/>
-   * To be implemented by the concrete sub-classes
-   */
-  @Override
-  public abstract boolean incrementToken() throws IOException;
+    private List<SKOSTypeAttribute.SKOSType> defaultTypes = Arrays.asList(SKOSAnalyzer.DEFAULT_SKOS_TYPES);
 
-  /**
-   * Replaces the current term (attributes) with term (attributes) from the stack
-   *
-   * @throws IOException if analyzer failed
-   */
-  protected void processTermOnStack() throws IOException {
-    ExpandedTerm expandedTerm = termStack.pop();
-    String term = expandedTerm.getTerm();
-    SKOSType termType = expandedTerm.getTermType();
-    String sTerm;
-    try {
-      CharsRefBuilder builder = new CharsRefBuilder();
-      sTerm = analyze(analyzer, term, builder).toString();
-    } catch (IllegalArgumentException e) {
-      // skip this term
-      return;
-    }
-    // copies the values of all attribute implementations from this state into
-    // the implementations of the target stream
-    restoreState(current);
-    // adds the expanded term to the term buffer
-    termAtt.setEmpty().append(sTerm);
-    //set position increment to zero to put multiple terms into the same position
-    posIncrAtt.setPositionIncrement(0);
-    // sets the type of the expanded term (pref, alt, broader, narrower, etc.)
-    skosAtt.setSkosType(termType);
-    // converts the SKOS Attribute to a payload, which is propagated to the index
-    byte[] bytes = PayloadHelper.encodeInt(skosAtt.getSkosType().ordinal());
-    payloadAtt.setPayload(new BytesRef(bytes));
-  }
-
-  public static CharsRef analyze(Analyzer analyzer, String text, CharsRefBuilder buffer)
-      throws IOException {
-    TokenStream ts = analyzer.tokenStream("", new StringReader(text));
-    CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
-    ts.reset();
-    while (ts.incrementToken()) {
-      int length = termAtt.length();
-      if (length == 0) {
-        throw new IllegalArgumentException("term: " + text + " analyzed to a zero-length token");
-      }
-      if (buffer.length() > 0) {
-        buffer.append(' ');
-      }
-      buffer.append(termAtt.buffer(), 0, length);
-    }
-    ts.end();
-    ts.close();
-    if (buffer.length() == 0) {
-      throw new IllegalArgumentException("term: " + text + " was completely eliminated by analyzer");
-    }
-    return buffer.get();
-  }
-
-  protected void pushLabelsToStack(String[] labels, SKOSType type) {
-    if (labels != null) {
-      for (String label : labels) {
-        termStack.push(new ExpandedTerm(label, type));
-      }
-    }
-  }
-
-  /**
-   * Helper class for capturing terms and term types
-   */
-  protected static class ExpandedTerm {
-
-    private final String term;
-    private final SKOSType termType;
-
-    protected ExpandedTerm(String term, SKOSType termType) {
-      this.term = term;
-      this.termType = termType;
+    /**
+     * Constructor
+     *
+     * @param input the TokenStream
+     * @param engine the engine delivering skos concepts
+     * @param analyzer the analyzer
+     * @param types the skos types to expand to
+     */
+    public AbstractSKOSFilter(TokenStream input, SKOSEngine engine, Analyzer analyzer, List<SKOSType> types) {
+        super(input);
+        termStack = new Stack<>();
+        this.engine = engine;
+        this.analyzer = analyzer;
+        this.types = new TreeSet<>(types != null && !types.isEmpty() ? types : defaultTypes);
+        this.termAtt = addAttribute(CharTermAttribute.class);
+        this.posIncrAtt = addAttribute(PositionIncrementAttribute.class);
+        this.payloadAtt = addAttribute(PayloadAttribute.class);
+        this.skosAtt = addAttribute(SKOSTypeAttribute.class);
+        this.offsettAtt = addAttribute(OffsetAttribute.class);
     }
 
-    protected String getTerm() {
-      return this.term;
+    /**
+     * Advances the stream to the next token. To be implemented by the concrete sub-classes
+     */
+    @Override
+    public abstract boolean incrementToken() throws IOException;
+
+    /**
+     * Replaces the current term (attributes) with term (attributes) from the stack
+     *
+     * @throws IOException if analyzer failed
+     */
+    protected void processTermOnStack() throws IOException {
+        ExpandedTerm expandedTerm = termStack.pop();
+        String term = expandedTerm.getTerm();
+        SKOSType termType = expandedTerm.getTermType();
+        String sTerm;
+        try {
+            CharsRefBuilder builder = new CharsRefBuilder();
+            sTerm = analyze(analyzer, term, builder).toString();
+        } catch (IllegalArgumentException e) {
+            // skip this term
+            return;
+        }
+        // copies the values of all attribute implementations from this state into
+        // the implementations of the target stream
+        restoreState(current);
+        // adds the expanded term to the term buffer
+        termAtt.setEmpty().append(sTerm);
+        // set position increment to zero to put multiple terms into the same position
+        posIncrAtt.setPositionIncrement(0);
+        // set offset of the original expression (usefull for highlighting)
+        if (expandedTerm.getStart() >= 0 && expandedTerm.getEnd() >= 0)
+            offsettAtt.setOffset(expandedTerm.getStart(), expandedTerm.getEnd());
+        // sets the type of the expanded term (pref, alt, broader, narrower, etc.)
+        skosAtt.setSkosType(termType);
+        // converts the SKOS Attribute to a payload, which is propagated to the index
+        byte[] bytes = PayloadHelper.encodeInt(skosAtt.getSkosType().ordinal());
+        payloadAtt.setPayload(new BytesRef(bytes));
     }
 
-    protected SKOSType getTermType() {
-      return this.termType;
+    public static CharsRef analyze(Analyzer analyzer, String text, CharsRefBuilder buffer) throws IOException {
+        TokenStream ts = analyzer.tokenStream("", new StringReader(text));
+        CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
+        ts.reset();
+        while (ts.incrementToken()) {
+            int length = termAtt.length();
+            if (length == 0) {
+                throw new IllegalArgumentException("term: " + text + " analyzed to a zero-length token");
+            }
+            if (buffer.length() > 0) {
+                buffer.append(' ');
+            }
+            buffer.append(termAtt.buffer(), 0, length);
+        }
+        ts.end();
+        ts.close();
+        if (buffer.length() == 0) {
+            throw new IllegalArgumentException("term: " + text + " was completely eliminated by analyzer");
+        }
+        return buffer.get();
     }
-  }
+
+    protected void pushLabelsToStack(ExpandedTerm origin, Collection<String> labels, SKOSType type) {
+        if (labels != null) {
+            for (String label : labels) {
+                termStack.push(new ExpandedTerm(label, type, origin.getStart(), origin.getEnd()));
+            }
+        }
+    }
+
+    /**
+     * Helper class for capturing terms and term types
+     */
+    protected static class ExpandedTerm {
+
+        private final String term;
+        private final SKOSType termType;
+
+        private final int start;
+        private final int end;
+
+        protected ExpandedTerm(String term, SKOSType termType) {
+            this.term = term;
+            this.termType = termType;
+            this.start = -1;
+            this.end = -1;
+
+        }
+
+        protected ExpandedTerm(String term, SKOSType termType, int start, int end) {
+            this.term = term;
+            this.termType = termType;
+            this.start = start;
+            this.end = end;
+
+        }
+
+        protected String getTerm() {
+            return this.term;
+        }
+
+        protected SKOSType getTermType() {
+            return this.termType;
+        }
+
+        protected int getStart() {
+            return start;
+        }
+
+        protected int getEnd() {
+            return end;
+        }
+
+    }
 }

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSAnalyzer.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSAnalyzer.java
@@ -16,9 +16,11 @@ package at.ac.univie.mminf.luceneSKOS.analysis;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngine;
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngineFactory;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
@@ -31,8 +33,9 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.util.CharArraySet;
 import org.apache.lucene.analysis.util.StopwordAnalyzerBase;
 
-import java.io.IOException;
-import java.io.Reader;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngineFactory;
 
 /**
  * An analyzer for expanding fields that contain either (i) URI references to
@@ -40,145 +43,155 @@ import java.io.Reader;
  */
 public class SKOSAnalyzer extends StopwordAnalyzerBase {
 
-  /**
-   * The supported expansion types
-   */
-  public enum ExpansionType {
-    URI, LABEL
-  }
-
-  /**
-   * Default expansion type
-   */
-  public static final ExpansionType DEFAULT_EXPANSION_TYPE = ExpansionType.LABEL;
-  private ExpansionType expansionType = DEFAULT_EXPANSION_TYPE;
-  /**
-   * Default skos types to expand to
-   */
-  public static final SKOSTypeAttribute.SKOSType[] DEFAULT_SKOS_TYPES = new SKOSTypeAttribute.SKOSType[]{
-      SKOSTypeAttribute.SKOSType.PREF, SKOSTypeAttribute.SKOSType.ALT, SKOSTypeAttribute.SKOSType.BROADER,
-      SKOSTypeAttribute.SKOSType.BROADERTRANSITIVE, SKOSTypeAttribute.SKOSType.NARROWER,
-      SKOSTypeAttribute.SKOSType.NARROWERTRANSITIVE};
-  private SKOSTypeAttribute.SKOSType[] types = DEFAULT_SKOS_TYPES;
-  /**
-   * A SKOS Engine instance
-   */
-  private SKOSEngine skosEngine;
-  /**
-   * The size of the buffer used for multi-term prediction
-   */
-  private int bufferSize = SKOSLabelFilter.DEFAULT_BUFFER_SIZE;
-  /**
-   * Default maximum allowed token length
-   */
-  public static final int DEFAULT_MAX_TOKEN_LENGTH = 255;
-  private int maxTokenLength = DEFAULT_MAX_TOKEN_LENGTH;
-  /**
-   * An unmodifiable set containing some common English words that are usually
-   * not useful for searching.
-   */
-  public static final CharArraySet STOP_WORDS_SET = StopAnalyzer.ENGLISH_STOP_WORDS_SET;
-
-  public SKOSAnalyzer(CharArraySet stopWords, SKOSEngine skosEngine, ExpansionType expansionType) {
-    super(stopWords);
-    this.skosEngine = skosEngine;
-    this.expansionType = expansionType;
-  }
-
-  public SKOSAnalyzer(SKOSEngine skosEngine, ExpansionType expansionType) {
-    this(STOP_WORDS_SET, skosEngine, expansionType);
-  }
-
-  public SKOSAnalyzer(Reader stopwords, SKOSEngine skosEngine, ExpansionType expansionType) throws IOException {
-    this(loadStopwordSet(stopwords), skosEngine, expansionType);
-  }
-
-  public SKOSAnalyzer(CharArraySet stopWords,
-                      String indexPath, String skosFile,
-                      ExpansionType expansionType, int bufferSize, String... languages)
-      throws IOException {
-    super(stopWords);
-    this.skosEngine = SKOSEngineFactory.getSKOSEngine(indexPath, skosFile, languages);
-    this.expansionType = expansionType;
-    this.bufferSize = bufferSize;
-  }
-
-  public SKOSAnalyzer(String indexPath, String skosFile,
-                      ExpansionType expansionType, int bufferSize, String... languages)
-      throws IOException {
-    this(STOP_WORDS_SET, indexPath, skosFile, expansionType, bufferSize, languages);
-  }
-
-  public SKOSAnalyzer(String indexPath, String skosFile,
-                      ExpansionType expansionType, int bufferSize) throws IOException {
-    this(indexPath, skosFile, expansionType, bufferSize, (String[]) null);
-  }
-
-  public SKOSAnalyzer(String indexPath, String skosFile,
-                      ExpansionType expansionType) throws IOException {
-    this(indexPath, skosFile, expansionType, SKOSLabelFilter.DEFAULT_BUFFER_SIZE);
-  }
-
-  public SKOSAnalyzer(Reader stopwords,
-                      String indexPath, String skosFile,
-                      ExpansionType expansionType, int bufferSize, String... languages)
-      throws IOException {
-    this(loadStopwordSet(stopwords), indexPath, skosFile,
-        expansionType, bufferSize, languages);
-  }
-
-  public SKOSTypeAttribute.SKOSType[] getTypes() {
-    return types;
-  }
-
-  public void setTypes(SKOSTypeAttribute.SKOSType... types) {
-    this.types = types;
-  }
-
-  /**
-   * Set maximum allowed token length. If a token is seen that exceeds this
-   * length then it is discarded. This setting only takes effect the next time
-   * tokenStream or tokenStream is called.
-   *
-   * @param length the length
-   */
-  public void setMaxTokenLength(int length) {
-    maxTokenLength = length;
-  }
-
-  /**
-   * Get maximum token length
-   *
-   * @return the maximum token length
-   * @see #setMaxTokenLength
-   */
-  public int getMaxTokenLength() {
-    return maxTokenLength;
-  }
-
-  @Override
-  protected TokenStreamComponents createComponents(String fileName) {
-    if (expansionType.equals(ExpansionType.URI)) {
-      final KeywordTokenizer src = new KeywordTokenizer();
-      TokenStream tok = new SKOSURIFilter(src, skosEngine, new StandardAnalyzer(), types);
-      tok = new LowerCaseFilter(tok);
-      return new TokenStreamComponents(src, tok);
-    } else {
-      final StandardTokenizer src = new StandardTokenizer();
-      src.setMaxTokenLength(maxTokenLength);
-      TokenStream tok = new StandardFilter(src);
-      // prior to this we get the classic behavior, standardfilter does it for us.
-      tok = new SKOSLabelFilter(tok, skosEngine, new StandardAnalyzer(), bufferSize, types);
-      tok = new LowerCaseFilter(tok);
-      tok = new StopFilter(tok, stopwords);
-      tok = new RemoveDuplicatesTokenFilter(tok);
-      return new TokenStreamComponents(src, tok) {
-        @Override
-        protected void setReader(final Reader reader) throws IOException {
-          src.setMaxTokenLength(maxTokenLength);
-          super.setReader(reader);
-        }
-      };
+    /**
+     * The supported expansion types
+     */
+    public enum ExpansionType {
+        URI, LABEL
     }
-  }
+    /**
+     * Default expansion type
+     */
+    public static final ExpansionType DEFAULT_EXPANSION_TYPE = ExpansionType.LABEL;
+    /**
+     * Default skos types to expand to
+     */
+    public static final SKOSType[] DEFAULT_SKOS_TYPES = new SKOSType[]{
+            SKOSType.PREF,
+            SKOSType.ALT,
+            SKOSType.BROADER,
+            SKOSType.BROADERTRANSITIVE,
+            SKOSType.NARROWER,
+            SKOSType.NARROWERTRANSITIVE
+    };
+
+    private ExpansionType expansionType = DEFAULT_EXPANSION_TYPE;
+
+    private List<SKOSType> types = Arrays.asList(DEFAULT_SKOS_TYPES);
+    /**
+     * A SKOS Engine instance
+     */
+    private SKOSEngine skosEngine;
+    /**
+     * Default maximum allowed token length
+     */
+    public static final int DEFAULT_MAX_TOKEN_LENGTH = 255;
+
+    private int maxTokenLength = DEFAULT_MAX_TOKEN_LENGTH;
+
+    private int bufferSize;
+    /**
+     * An unmodifiable set containing some common English words that are usually
+     * not useful for searching.
+     */
+    public static final CharArraySet STOP_WORDS_SET = StopAnalyzer.ENGLISH_STOP_WORDS_SET;
+
+    public SKOSAnalyzer(SKOSEngine skosEngine, ExpansionType expansionType) {
+        this(STOP_WORDS_SET, skosEngine, expansionType, 4, Arrays.asList(DEFAULT_SKOS_TYPES));
+    }
+
+    public SKOSAnalyzer(CharArraySet stopWords, SKOSEngine skosEngine, ExpansionType expansionType, int bufferSize, List<SKOSType> types) {
+        super(stopWords);
+        this.skosEngine = skosEngine;
+        this.expansionType = expansionType;
+        this.bufferSize = bufferSize;
+        this.types = types;
+    }
+
+    public SKOSAnalyzer(CharArraySet stopWords, SKOSEngine skosEngine, ExpansionType expansionType) {
+        super(stopWords);
+        this.skosEngine = skosEngine;
+        this.expansionType = expansionType;
+    }
+
+    public SKOSAnalyzer(Reader stopwords, SKOSEngine skosEngine, ExpansionType expansionType) throws IOException {
+        this(loadStopwordSet(stopwords), skosEngine, expansionType);
+    }
+
+    public SKOSAnalyzer(CharArraySet stopWords,
+                        String indexPath, String skosFile,
+                        ExpansionType expansionType, int bufferSize, String... languages)
+            throws IOException {
+        super(stopWords);
+        this.skosEngine = SKOSEngineFactory.getSKOSEngine(indexPath, skosFile, languages != null ? Arrays.asList(languages) : null);
+        this.expansionType = expansionType;
+        this.bufferSize = bufferSize;
+    }
+
+    public SKOSAnalyzer(String indexPath, String skosFile,
+                        ExpansionType expansionType, int bufferSize, String... languages)
+            throws IOException {
+        this(STOP_WORDS_SET, indexPath, skosFile, expansionType, bufferSize, languages);
+    }
+
+    public SKOSAnalyzer(String indexPath, String skosFile,
+                        ExpansionType expansionType, int bufferSize) throws IOException {
+        this(indexPath, skosFile, expansionType, bufferSize, null);
+    }
+
+    public SKOSAnalyzer(String indexPath, String skosFile,
+                        ExpansionType expansionType) throws IOException {
+        this(indexPath, skosFile, expansionType, SKOSLabelFilter.DEFAULT_BUFFER_SIZE);
+    }
+
+    public SKOSAnalyzer(Reader stopwords,
+                        String indexPath, String skosFile,
+                        ExpansionType expansionType, int bufferSize, String... languages)
+            throws IOException {
+        this(loadStopwordSet(stopwords), indexPath, skosFile,
+                expansionType, bufferSize, languages);
+    }
+
+    public List<SKOSType> getTypes() {
+        return types;
+    }
+
+    public void setTypes(List<SKOSType> types) {
+        this.types = types;
+    }
+
+    /**
+     * Set maximum allowed token length. If a token is seen that exceeds this
+     * length then it is discarded. This setting only takes effect the next time
+     * tokenStream or tokenStream is called.
+     * @param length the length
+     */
+    public void setMaxTokenLength(int length) {
+        maxTokenLength = length;
+    }
+
+    /**
+     * Get maximum token length
+     * @see #setMaxTokenLength
+     * @return the maximum token length
+     */
+    public int getMaxTokenLength() {
+        return maxTokenLength;
+    }
+
+    @Override
+    protected TokenStreamComponents createComponents(String fileName) {
+        if (expansionType.equals(ExpansionType.URI)) {
+            final KeywordTokenizer src = new KeywordTokenizer();
+            TokenStream tok = new SKOSURIFilter(src, skosEngine, new StandardAnalyzer(), types);
+            tok = new LowerCaseFilter(tok);
+            return new TokenStreamComponents(src, tok);
+        } else {
+            final StandardTokenizer src = new StandardTokenizer();
+            src.setMaxTokenLength(maxTokenLength);
+            TokenStream tok = new StandardFilter(src);
+            // prior to this we get the classic behavior, standardfilter does it for us.
+            tok = new SKOSLabelFilter(tok, skosEngine, new StandardAnalyzer(), bufferSize, types);
+            tok = new LowerCaseFilter(tok);
+            tok = new StopFilter(tok, stopwords);
+            tok = new RemoveDuplicatesTokenFilter(tok);
+            return new TokenStreamComponents(src, tok) {
+                @Override
+                protected void setReader(final Reader reader) throws IOException {
+                    src.setMaxTokenLength(maxTokenLength);
+                    super.setReader(reader);
+                }
+            };
+        }
+    }
 }

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSLabelFilter.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSLabelFilter.java
@@ -16,156 +16,137 @@ package at.ac.univie.mminf.luceneSKOS.analysis;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngine;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 
-import java.io.IOException;
-import java.util.LinkedList;
-import java.util.Queue;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
 
 /**
- * A Lucene TokenFilter that supports label-based term expansion as described in
- * https://code.google.com/p/lucene-skos/wiki/UseCases#UC2:_Label-based_term_expansion.
- *
- * It takes labels (String values) as input and searches a given SKOS vocabulary
- * for matching concepts (based on their prefLabels). If a match is found, it
- * adds the concept's labels to the output token stream.
+ * A Lucene TokenFilter that supports label-based term expansion as described in https://code.google.com/p/lucene-skos/wiki/UseCases#UC2:_Label-based_term_expansion. It takes labels (String values) as input and searches a given SKOS vocabulary for matching concepts (based on their prefLabels). If a match is found, it adds the concept's labels to the output token stream.
  */
 public final class SKOSLabelFilter extends AbstractSKOSFilter {
 
-  public static final int DEFAULT_BUFFER_SIZE = 1;
-  /* the size of the buffer used for multi-term prediction */
-  private int bufferSize = DEFAULT_BUFFER_SIZE;
-  /* a list serving as token buffer between consumed and consuming stream */
-  private Queue<State> buffer = new LinkedList<>();
+    public static final int DEFAULT_BUFFER_SIZE = 1;
+    /* the size of the buffer used for multi-term prediction */
+    private int bufferSize = DEFAULT_BUFFER_SIZE;
+    /* a list serving as token buffer between consumed and consuming stream */
+    private Queue<State> buffer = new LinkedList<>();
 
-  /**
-   * Constructor for multi-term expansion support. Takes an input token
-   * stream, the SKOS engine, and an integer indicating the maximum token
-   * length of the preferred labels in the SKOS vocabulary.
-   *
-   * @param input      the consumed token stream
-   * @param engine     the skos expansion engine
-   * @param analyzer   the analyzer
-   * @param bufferSize the length of the longest pref-label to consider
-   *                   (needed for mult-term expansion)
-   * @param types      the skos types to expand to
-   */
-  public SKOSLabelFilter(TokenStream input, SKOSEngine engine,
-                         Analyzer analyzer, int bufferSize, SKOSTypeAttribute.SKOSType... types) {
-    super(input, engine, analyzer, types);
-    this.bufferSize = bufferSize;
-  }
+    /**
+     * Constructor for multi-term expansion support. Takes an input token stream, the SKOS engine, and an integer indicating the maximum token length of the preferred labels in the SKOS vocabulary.
+     *
+     * @param input the consumed token stream
+     * @param engine the skos expansion engine
+     * @param analyzer the analyzer
+     * @param bufferSize the length of the longest pref-label to consider (needed for mult-term expansion)
+     * @param types the skos types to expand to
+     */
+    public SKOSLabelFilter(TokenStream input, SKOSEngine engine, Analyzer analyzer, int bufferSize, List<SKOSType> types) {
+        super(input, engine, analyzer, types);
+        this.bufferSize = bufferSize;
+    }
 
-  /**
-   * Advances the stream to the next token
-   */
-  @Override
-  public boolean incrementToken() throws IOException {
-        /* there are expanded terms for the given token */
-    if (termStack.size() > 0) {
-      processTermOnStack();
-      return true;
+    /**
+     * Advances the stream to the next token
+     */
+    @Override
+    public boolean incrementToken() throws IOException {
+        // there are expanded terms for the given token
+        if (termStack.size() > 0) {
+            processTermOnStack();
+            return true;
+        }
+        while (buffer.size() < bufferSize && input.incrementToken()) {
+            buffer.add(input.captureState());
+        }
+        if (buffer.isEmpty()) {
+            return false;
+        }
+        restoreState(buffer.peek());
+        // check whether there are expanded terms for a given token
+        if (addAliasesToStack()) {
+            // if yes, capture the state of all attributes
+            current = captureState();
+        }
+        buffer.remove();
+        return true;
     }
-    while (buffer.size() < bufferSize && input.incrementToken()) {
-      buffer.add(input.captureState());
-    }
-    if (buffer.isEmpty()) {
-      return false;
-    }
-    restoreState(buffer.peek());
-        /* check whether there are expanded terms for a given token */
-    if (addAliasesToStack()) {
-            /* if yes, capture the state of all attributes */
-      current = captureState();
-    }
-    buffer.remove();
-    return true;
-  }
 
-  private boolean addAliasesToStack() throws IOException {
-    for (int i = buffer.size(); i > 0; i--) {
-      String inputTokens = bufferToString(i);
-      if (addTermsToStack(inputTokens)) {
-        break;
-      }
+    private boolean addAliasesToStack() throws IOException {
+        for (int i = buffer.size(); i > 0; i--) {
+            ExpandedTerm inputTokens = bufferToTerm(i);
+            if (addTermsToStack(inputTokens)) {
+                break;
+            }
+        }
+        return !termStack.isEmpty();
     }
-    return !termStack.isEmpty();
-  }
 
-  /**
-   * Converts the first x=noTokens states in the queue to a concatenated token
-   * string separated by white spaces
-   *
-   * @param noTokens the number of tokens
-   * @return the concatenated token string
-   */
-  private String bufferToString(int noTokens) {
-    State entered = captureState();
-    State[] bufferedStates = buffer.toArray(new State[buffer.size()]);
-    StringBuilder builder = new StringBuilder();
-    builder.append(termAtt.toString());
-    restoreState(bufferedStates[0]);
-    for (int i = 1; i < noTokens; i++) {
-      restoreState(bufferedStates[i]);
-      builder.append(" ").append(termAtt.toString());
+    /**
+     * Converts the first x=noTokens states in the queue to a concatenated token string separated by white spaces
+     * 
+     * @param noTokens the number of tokens
+     * @return the concatenated token string
+     */
+    private ExpandedTerm bufferToTerm(int noTokens) {
+        State entered = captureState();
+        State[] bufferedStates = buffer.toArray(new State[buffer.size()]);
+        StringBuilder builder = new StringBuilder();
+        builder.append(termAtt.toString());
+        restoreState(bufferedStates[0]);
+        int start = offsettAtt.startOffset();
+        for (int i = 1; i < noTokens; i++) {
+            restoreState(bufferedStates[i]);
+            builder.append(" ").append(termAtt.toString());
+        }
+        int end = offsettAtt.endOffset();
+        restoreState(entered);
+        return new ExpandedTerm(builder.toString(), null, start, end);
     }
-    restoreState(entered);
-    return builder.toString();
-  }
 
-  /**
-   * Add terms to stack
-   * Assumes that the given term is a textual token
-   *
-   * @param term the given term
-   * @return true if term stack is not empty
-   */
-  public boolean addTermsToStack(String term) {
-    try {
-      String[] conceptURIs = engine.getConcepts(term);
-      for (String conceptURI : conceptURIs) {
-        if (types.contains(SKOSTypeAttribute.SKOSType.PREF)) {
-          String[] prefLabels = engine.getPrefLabels(conceptURI);
-          pushLabelsToStack(prefLabels, SKOSTypeAttribute.SKOSType.PREF);
+    /**
+     * Add terms to stack Assumes that the given term is a textual token
+     * 
+     * @param term the given term
+     * @return true if term stack is not empty
+     */
+    public boolean addTermsToStack(ExpandedTerm term) throws IOException {
+        Collection<String> conceptURIs = engine.getConcepts(term.getTerm());
+        for (String conceptURI : conceptURIs) {
+            if (types.contains(SKOSType.PREF)) {
+                pushLabelsToStack(term, engine.getPrefLabels(conceptURI), SKOSType.PREF);
+            }
+            if (types.contains(SKOSType.ALT)) {
+                pushLabelsToStack(term, engine.getAltLabels(conceptURI), SKOSType.ALT);
+            }
+            if (types.contains(SKOSType.HIDDEN)) {
+                pushLabelsToStack(term, engine.getHiddenLabels(conceptURI), SKOSType.HIDDEN);
+            }
+            if (types.contains(SKOSType.BROADER)) {
+                pushLabelsToStack(term, engine.getBroaderLabels(conceptURI), SKOSType.BROADER);
+            }
+            if (types.contains(SKOSType.BROADERTRANSITIVE)) {
+                pushLabelsToStack(term, engine.getBroaderTransitiveLabels(conceptURI), SKOSType.BROADERTRANSITIVE);
+            }
+            if (types.contains(SKOSType.NARROWER)) {
+                pushLabelsToStack(term, engine.getNarrowerLabels(conceptURI), SKOSType.NARROWER);
+            }
+            if (types.contains(SKOSType.NARROWERTRANSITIVE)) {
+                pushLabelsToStack(term, engine.getNarrowerTransitiveLabels(conceptURI), SKOSType.NARROWERTRANSITIVE);
+            }
+            if (types.contains(SKOSType.RELATED)) {
+                pushLabelsToStack(term, engine.getRelatedLabels(conceptURI), SKOSType.RELATED);
+            }
+
         }
-        if (types.contains(SKOSTypeAttribute.SKOSType.ALT)) {
-          String[] altLabels = engine.getAltLabels(conceptURI);
-          pushLabelsToStack(altLabels, SKOSTypeAttribute.SKOSType.ALT);
-        }
-        if (types.contains(SKOSTypeAttribute.SKOSType.HIDDEN)) {
-          String[] hiddenLabels = engine.getHiddenLabels(conceptURI);
-          pushLabelsToStack(hiddenLabels, SKOSTypeAttribute.SKOSType.HIDDEN);
-        }
-        if (types.contains(SKOSTypeAttribute.SKOSType.BROADER)) {
-          String[] broaderLabels = engine.getBroaderLabels(conceptURI);
-          pushLabelsToStack(broaderLabels, SKOSTypeAttribute.SKOSType.BROADER);
-        }
-        if (types.contains(SKOSTypeAttribute.SKOSType.BROADERTRANSITIVE)) {
-          String[] broaderTransitiveLabels = engine
-              .getBroaderTransitiveLabels(conceptURI);
-          pushLabelsToStack(broaderTransitiveLabels, SKOSTypeAttribute.SKOSType.BROADERTRANSITIVE);
-        }
-        if (types.contains(SKOSTypeAttribute.SKOSType.NARROWER)) {
-          String[] narrowerLabels = engine.getNarrowerLabels(conceptURI);
-          pushLabelsToStack(narrowerLabels, SKOSTypeAttribute.SKOSType.NARROWER);
-        }
-        if (types.contains(SKOSTypeAttribute.SKOSType.NARROWERTRANSITIVE)) {
-          String[] narrowerTransitiveLabels = engine
-              .getNarrowerTransitiveLabels(conceptURI);
-          pushLabelsToStack(narrowerTransitiveLabels,
-              SKOSTypeAttribute.SKOSType.NARROWERTRANSITIVE);
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("error when accessing SKOS engine: " + e.getMessage());
+        return !termStack.isEmpty();
     }
-    return !termStack.isEmpty();
-  }
 
-  public int getBufferSize() {
-    return this.bufferSize;
-  }
 }

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSTypeAttribute.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSTypeAttribute.java
@@ -1,0 +1,51 @@
+package at.ac.univie.mminf.luceneSKOS.analysis;
+
+/**
+ * Copyright 2010 Bernhard Haslhofer 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.lucene.util.Attribute;
+
+/**
+ * This class represents SKOS-specific meta-information that is assigned to
+ * tokens during the analysis phase.
+ *
+ * Note: when tokens are posted to the index as terms, attribute information is
+ * lost unless it is encoded in the terms' payload.
+ */
+public interface SKOSTypeAttribute extends Attribute {
+
+    /**
+     * An enumeration of supported SKOS concept types
+     */
+    enum SKOSType {
+
+        PREF, ALT, HIDDEN, BROADER, NARROWER, BROADERTRANSITIVE, NARROWERTRANSITIVE, RELATED;
+    }
+
+    /**
+     * Returns the SKOS type
+     *
+     * @return SKOSType
+     */
+    SKOSType getSkosType();
+
+    /**
+     * Sets this Token's SKOSType.
+     *
+     * @param skosType the SKOS type
+     */
+    void setSkosType(SKOSType skosType);
+}

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSTypeAttributeImpl.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSTypeAttributeImpl.java
@@ -1,0 +1,89 @@
+package at.ac.univie.mminf.luceneSKOS.analysis;
+
+/**
+ * Copyright 2010 Bernhard Haslhofer 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.lucene.util.AttributeImpl;
+
+/**
+ * The SKOSType of a Token.
+ */
+public class SKOSTypeAttributeImpl extends AttributeImpl implements
+        SKOSTypeAttribute, Cloneable {
+
+    private SKOSType skosType;
+
+    /**
+     * Initialize this attribute with no SKOSType.
+     */
+    public SKOSTypeAttributeImpl() {
+        super();
+    }
+
+    /**
+     * Initialize this attribute with the given SKOSType.
+     * @param skosType the SKOS type
+     */
+    public SKOSTypeAttributeImpl(SKOSType skosType) {
+        super();
+        this.skosType = skosType;
+    }
+
+    /**
+     * Returns this Token's SKOSType.
+     */
+    @Override
+    public SKOSType getSkosType() {
+        return skosType;
+    }
+
+    /**
+     * Sets this Token's SKOSType.
+     */
+    @Override
+    public void setSkosType(SKOSType skosType) {
+        this.skosType = skosType;
+    }
+
+    @Override
+    public void clear() {
+        skosType = null;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other instanceof SKOSTypeAttribute) {
+            final SKOSTypeAttributeImpl otherImpl = (SKOSTypeAttributeImpl) other;
+            return (this.skosType == null ? otherImpl.skosType == null
+                    : this.skosType.equals(otherImpl.skosType));
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return (skosType == null) ? 0 : skosType.hashCode();
+    }
+
+    @Override
+    public void copyTo(AttributeImpl target) {
+        SKOSTypeAttribute type = (SKOSTypeAttribute) target;
+        type.setSkosType(skosType);
+    }
+}

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSURIFilter.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/SKOSURIFilter.java
@@ -16,93 +16,74 @@ package at.ac.univie.mminf.luceneSKOS.analysis;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngine;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute.SKOSType;
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 
-import java.io.IOException;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
 
 /**
- * A Lucene TokenFilter that supports URI-based term expansion as described in
- * https://code.
- * google.com/p/lucene-skos/wiki/UseCases#UC1:_URI-based_term_expansion
- *
- * It takes references to SKOS concepts (URIs) as input and searches a given
- * SKOS vocabulary for matching concepts. If a match is found, it adds the
- * concept's labels to the output token stream.
+ * A Lucene TokenFilter that supports URI-based term expansion as described in https://code. google.com/p/lucene-skos/wiki/UseCases#UC1:_URI-based_term_expansion It takes references to SKOS concepts (URIs) as input and searches a given SKOS vocabulary for matching concepts. If a match is found, it adds the concept's labels to the output token stream.
  */
 public final class SKOSURIFilter extends AbstractSKOSFilter {
 
-  public SKOSURIFilter(TokenStream input, SKOSEngine skosEngine,
-                       Analyzer analyzer, SKOSType... types) {
-    super(input, skosEngine, analyzer, types);
-  }
+    public SKOSURIFilter(TokenStream input, SKOSEngine skosEngine, Analyzer analyzer, List<SKOSType> types) {
+        super(input, skosEngine, analyzer, types);
+    }
 
-  /**
-   * Advances the stream to the next token
-   */
-  @Override
-  public boolean incrementToken() throws IOException {
-
+    /**
+     * Advances the stream to the next token
+     */
+    @Override
+    public boolean incrementToken() throws IOException {
         /* there are expanded terms for the given token */
-    if (termStack.size() > 0) {
-      processTermOnStack();
-      return true;
-    }
-
+        if (termStack.size() > 0) {
+            processTermOnStack();
+            return true;
+        }
         /* no more tokens on the consumed stream -> end of stream */
-    if (!input.incrementToken()) {
-      return false;
-    }
-
+        if (!input.incrementToken()) {
+            return false;
+        }
         /* check whether there are expanded terms for a given token */
-    if (addTermsToStack(termAtt.toString())) {
-
+        if (addTermsToStack(new ExpandedTerm(termAtt.toString(), null, offsettAtt.startOffset(), offsettAtt.endOffset()))) {
             /* if yes, capture the state of all attributes */
-      current = captureState();
+            current = captureState();
+        }
+        return true;
     }
 
-    return true;
-  }
-
-  /**
-   * Assumes that the given term is a concept URI
-   *
-   * @param term the given term
-   * @return true if term stack is not empty
-   */
-  public boolean addTermsToStack(String term) {
-    try {
-      if (types.contains(SKOSType.PREF)) {
-        String[] prefLabels = engine.getPrefLabels(term);
-        pushLabelsToStack(prefLabels, SKOSType.PREF);
-      }
-      if (types.contains(SKOSType.ALT)) {
-        String[] altLabels = engine.getAltLabels(term);
-        pushLabelsToStack(altLabels, SKOSType.ALT);
-      }
-      if (types.contains(SKOSType.BROADER)) {
-        String[] broaderLabels = engine.getBroaderLabels(term);
-        pushLabelsToStack(broaderLabels, SKOSType.BROADER);
-      }
-      if (types.contains(SKOSType.BROADERTRANSITIVE)) {
-        String[] broaderTransitiveLabels = engine
-            .getBroaderTransitiveLabels(term);
-        pushLabelsToStack(broaderTransitiveLabels, SKOSType.BROADERTRANSITIVE);
-      }
-      if (types.contains(SKOSType.NARROWER)) {
-        String[] narrowerLabels = engine.getNarrowerLabels(term);
-        pushLabelsToStack(narrowerLabels, SKOSType.NARROWER);
-      }
-      if (types.contains(SKOSType.NARROWERTRANSITIVE)) {
-        String[] narrowerTransitiveLabels = engine
-            .getNarrowerTransitiveLabels(term);
-        pushLabelsToStack(narrowerTransitiveLabels, SKOSType.NARROWERTRANSITIVE);
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Error when accessing SKOS Engine.\n" + e.getMessage());
+    /**
+     * Assumes that the given term is a concept URI
+     * 
+     * @param term the given term
+     * @return true if term stack is not empty
+     */
+    public boolean addTermsToStack(ExpandedTerm term) throws IOException {
+        if (types.contains(SKOSType.PREF)) {
+            pushLabelsToStack(term, engine.getPrefLabels(term.getTerm()), SKOSType.PREF);
+        }
+        if (types.contains(SKOSType.ALT)) {
+            pushLabelsToStack(term, engine.getAltLabels(term.getTerm()), SKOSType.ALT);
+        }
+        if (types.contains(SKOSType.BROADER)) {
+            pushLabelsToStack(term, engine.getBroaderLabels(term.getTerm()), SKOSType.BROADER);
+        }
+        if (types.contains(SKOSType.BROADERTRANSITIVE)) {
+            pushLabelsToStack(term, engine.getBroaderTransitiveLabels(term.getTerm()), SKOSType.BROADERTRANSITIVE);
+        }
+        if (types.contains(SKOSType.NARROWER)) {
+            pushLabelsToStack(term, engine.getNarrowerLabels(term.getTerm()), SKOSType.NARROWER);
+        }
+        if (types.contains(SKOSType.NARROWERTRANSITIVE)) {
+            pushLabelsToStack(term, engine.getNarrowerTransitiveLabels(term.getTerm()), SKOSType.NARROWERTRANSITIVE);
+        }
+        if (types.contains(SKOSType.RELATED)) {
+            pushLabelsToStack(term, engine.getRelatedLabels(term.getTerm()), SKOSType.RELATED);
+        }
+        return !termStack.isEmpty();
     }
-    return !termStack.isEmpty();
-  }
 }

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/SKOSEngine.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/SKOSEngine.java
@@ -1,0 +1,161 @@
+package at.ac.univie.mminf.luceneSKOS.analysis.engine;
+
+/**
+ * Copyright 2010 Bernhard Haslhofer 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * An interface to the used SKOS model. It provides accessors to all the data needed for the expansion process.
+ */
+public interface SKOSEngine {
+
+    /**
+     * Returns the preferred labels (prefLabel) for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the preferrrd label
+     * @throws IOException if method fails
+     */
+    Collection<String> getPrefLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns the alternative labels (altLabel) for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the alternative labels
+     * @throws IOException if method fails
+     */
+    Collection<String> getAltLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns the hidden labels (hiddenLabel) for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the hidden labels
+     * @throws IOException if method fails
+     */
+    Collection<String> getHiddenLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns the related labels (related) for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the related labels
+     * @throws IOException if method fails
+     */
+    Collection<String> getRelatedLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns the URIs of all related concepts for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the related concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getRelatedConcepts(String conceptURI) throws IOException;
+
+    /**
+     * Returns the URIs of all broader concepts for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the broader concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getBroaderConcepts(String conceptURI) throws IOException;
+
+    /**
+     * Returns the URIs of all narrower concepts for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the narrower concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getNarrowerConcepts(String conceptURI) throws IOException;
+
+    /**
+     * Returns the labels (prefLabel + altLabel) of ALL broader concepts for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the broader labels
+     * @throws IOException if method fails
+     */
+    Collection<String> getBroaderLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns the labels (prefLabel + altLabel) of ALL narrower concepts for a given URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the narrower labels
+     * @throws IOException if method fails
+     */
+    Collection<String> getNarrowerLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns the URIs of all broader transitive concepts for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the broader transitive concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getBroaderTransitiveConcepts(String conceptURI) throws IOException;
+
+    /**
+     * Returns the URIs of all narrower transitive concepts for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the nattower transitive concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getNarrowerTransitiveConcepts(String conceptURI) throws IOException;
+
+    /**
+     * Returns the labels (prefLabel + altLabel) of ALL broader transitive concepts for a given concept URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the broader transitive concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getBroaderTransitiveLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns the labels (prefLabel + altLabel) of ALL narrower transitive concepts for a given URI
+     *
+     * @param conceptURI the concept URI
+     * @return String[] the narrower trasitive concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getNarrowerTransitiveLabels(String conceptURI) throws IOException;
+
+    /**
+     * Returns all concepts (URIs) matching a given label
+     *
+     * @param label the label
+     * @return String[] the concepts
+     * @throws IOException if method fails
+     */
+    Collection<String> getConcepts(String label) throws IOException;
+
+    /**
+     * Returns all alternative terms for a given label
+     *
+     * @param label the label
+     * @return String[] the alternative terms
+     * @throws IOException if method fails
+     */
+    Collection<String> getAltTerms(String label) throws IOException;
+}

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/SKOSEngineFactory.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/SKOSEngineFactory.java
@@ -1,0 +1,91 @@
+package at.ac.univie.mminf.luceneSKOS.analysis.engine;
+
+/**
+ * Copyright 2010 Bernhard Haslhofer 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.jena.SKOSEngineImpl;
+
+/**
+ * This factory instantiates the various kinds of SKOSEngine implementations
+ */
+public class SKOSEngineFactory {
+
+    /**
+     * Sets up a SKOS Engine from a local rdf file (serialized in any rdf
+     * serialization format) or a remote rdf serialization identified by a URI
+     * and reachable via HTTP.
+     *
+     * @param indexPath     the index path
+     * @param filenameOrURI the skos file
+     * @return a new SKOSEngine instance
+     * @throws IOException if SKOS engine can not be instantiated
+     */
+    public static SKOSEngine getSKOSEngine(String indexPath, String filenameOrURI) throws IOException {
+      return new SKOSEngineImpl(indexPath, filenameOrURI, null);
+    }
+  
+    /**
+     * Sets up a SKOS Engine from a given InputStream. The inputstream must
+     * deliver data in a valid RDF serialization format.
+     *
+     * @param inputStream the input stream
+     * @param lang the serialization format (N3, RDF/XML, TURTLE)
+     * @return a new SKOSEngine instance
+     * @throws IOException if SKOS engine can not be instantiated
+     */
+    public static SKOSEngine getSKOSEngine(InputStream inputStream, String lang) throws IOException {
+        return new SKOSEngineImpl(inputStream, lang);
+    }
+
+    /**
+     * Sets up a SKOS Engine from a given rdf file (serialized in any RDF
+     * serialization format) and considers only those concept labels that are
+     * defined in the language parameter
+     *
+     * @param indexPath     the index path
+     * @param filenameOrURI the skos file
+     * @param languages the languages to be considered
+     * @return SKOSEngine
+     * @throws IOException if SKOS engine can not be instantiated
+     */
+    public static SKOSEngine getSKOSEngine(String indexPath, String filenameOrURI, List<String> languages) throws IOException {
+        return new SKOSEngineImpl(indexPath, filenameOrURI, languages);
+    }
+
+
+    /**
+     * Sets up a SKOS Engine from a given InputStream. The inputstream must
+     * deliver data in a valid RDF serialization format.
+     *
+     * @param inputStream the input stream
+     * @param format the serialization format (N3, RDF/XML, TURTLE)
+     * @param languages the languages to be considered
+     * @return a new SKOSEngine instance
+     * @throws IOException if SKOS engine can not be instantiated
+     */
+    public static SKOSEngine getSKOSEngine(InputStream inputStream, String format, List<String> languages) throws IOException {
+        return new SKOSEngineImpl(inputStream, format, languages);
+    }
+
+    public static SKOSEngine getSKOSEngine(InputStream inputStream, String format, String... languages) throws IOException {
+        return new SKOSEngineImpl(inputStream, format, Arrays.asList(languages));
+    }
+}

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/jena/SKOS.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/jena/SKOS.java
@@ -1,0 +1,133 @@
+package at.ac.univie.mminf.luceneSKOS.analysis.engine.jena;
+
+import com.hp.hpl.jena.ontology.AnnotationProperty;
+import com.hp.hpl.jena.ontology.DatatypeProperty;
+import com.hp.hpl.jena.ontology.ObjectProperty;
+import com.hp.hpl.jena.ontology.OntClass;
+import com.hp.hpl.jena.ontology.OntModel;
+import com.hp.hpl.jena.ontology.OntModelSpec;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+import com.hp.hpl.jena.rdf.model.Resource;
+
+/**
+ * Vocabulary definitions from skos.rdf
+ */
+public interface SKOS {
+    /**
+     * The ontology model that holds the vocabulary terms
+     */
+    OntModel m_model = ModelFactory.createOntologyModel( OntModelSpec.OWL_MEM, null );
+    
+    /**
+     * The namespace of the vocabulary as a string
+     */
+    String NS = "http://www.w3.org/2004/02/skos/core#";
+
+    /**
+     * The namespace of the vocabulary as a resource
+     */
+    Resource NAMESPACE = m_model.createResource( NS );
+    
+    ObjectProperty broadMatch = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#broadMatch" );
+    
+    /**
+     * Broader concepts are typically rendered as parents in a concept hierarchy(tree).
+     */
+    ObjectProperty broader = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#broader" );
+    
+    ObjectProperty broaderTransitive = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#broaderTransitive" );
+    
+    ObjectProperty closeMatch = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#closeMatch" );
+    
+    /**
+     * skos:exactMatch is disjoint with each of the properties skos:broadMatch and
+     *  skos:relatedMatch.
+     */
+    ObjectProperty exactMatch = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#exactMatch" );
+    
+    ObjectProperty hasTopConcept = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#hasTopConcept" );
+    
+    ObjectProperty inScheme = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#inScheme" );
+    
+    /**
+     * These concept mapping relations mirror semantic relations, and the data model
+     * defined below is similar (with the exception of skos:exactMatch) to the data
+     * model defined for semantic relations. A distinct vocabulary is provided for
+     * concept mapping relations, to provide a convenient way to differentiate links
+     * within a concept scheme from links between concept schemes. However, this
+     * pattern of usage is not a formal requirement of the SKOS data model, and relies
+     * on informal definitions of best practice.
+     */
+    ObjectProperty mappingRelation = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#mappingRelation" );
+    
+    ObjectProperty member = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#member" );
+    
+    /**
+     * For any resource, every item in the list given as the value of the skos:memberList
+     * property is also a value of the skos:member property.
+     */
+    ObjectProperty memberList = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#memberList" );
+    
+    ObjectProperty narrowMatch = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#narrowMatch" );
+    
+    /**
+     * Narrower concepts are typically rendered as children in a concept hierarchy (tree).
+     */
+    ObjectProperty narrower = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#narrower" );
+    
+    ObjectProperty narrowerTransitive = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#narrowerTransitive" );
+    
+    /**
+     * skos:related is disjoint with skos:broaderTransitive
+     */
+    ObjectProperty related = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#related" );
+    
+    ObjectProperty relatedMatch = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#relatedMatch" );
+    
+    ObjectProperty semanticRelation = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#semanticRelation" );
+    
+    ObjectProperty topConceptOf = m_model.createObjectProperty( "http://www.w3.org/2004/02/skos/core#topConceptOf" );
+    
+    DatatypeProperty notation = m_model.createDatatypeProperty( "http://www.w3.org/2004/02/skos/core#notation" );
+    
+    /**
+     * The range of skos:altLabel is the class of RDF plain literals.skos:prefLabel,
+     * skos:altLabel and skos:hiddenLabel are pairwise disjoint properties.
+     */
+    AnnotationProperty altLabel = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#altLabel" );
+    
+    AnnotationProperty changeNote = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#changeNote" );
+    
+    AnnotationProperty definition = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#definition" );
+    
+    AnnotationProperty editorialNote = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#editorialNote" );
+    
+    AnnotationProperty example = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#example" );
+    
+    /**
+     * The range of skos:hiddenLabel is the class of RDF plain literals.skos:prefLabel,
+     *  skos:altLabel and skos:hiddenLabel are pairwise disjoint properties.
+     */
+    AnnotationProperty hiddenLabel = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#hiddenLabel" );
+    
+    AnnotationProperty historyNote = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#historyNote" );
+    
+    AnnotationProperty note = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#note" );
+    
+    /**
+     * A resource has no more than one value of skos:prefLabel per language tag.skos:prefLabel,
+     * skos:altLabel and skos:hiddenLabel are pairwise disjoint properties.The range
+     * of skos:prefLabel is the class of RDF plain literals.
+     */
+    AnnotationProperty prefLabel = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#prefLabel" );
+    
+    AnnotationProperty scopeNote = m_model.createAnnotationProperty( "http://www.w3.org/2004/02/skos/core#scopeNote" );
+    
+    OntClass Collection = m_model.createClass( "http://www.w3.org/2004/02/skos/core#Collection" );
+    
+    OntClass Concept = m_model.createClass( "http://www.w3.org/2004/02/skos/core#Concept" );
+    
+    OntClass ConceptScheme = m_model.createClass( "http://www.w3.org/2004/02/skos/core#ConceptScheme" );
+    
+    OntClass OrderedCollection = m_model.createClass( "http://www.w3.org/2004/02/skos/core#OrderedCollection" );
+}

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/jena/SKOSEngineImpl.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/analysis/engine/jena/SKOSEngineImpl.java
@@ -1,0 +1,533 @@
+package at.ac.univie.mminf.luceneSKOS.analysis.engine.jena;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.log4j.Logger;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.SimpleAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.RAMDirectory;
+
+import com.hp.hpl.jena.ontology.AnnotationProperty;
+import com.hp.hpl.jena.ontology.ObjectProperty;
+import com.hp.hpl.jena.rdf.model.Literal;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+import com.hp.hpl.jena.rdf.model.RDFNode;
+import com.hp.hpl.jena.rdf.model.ResIterator;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.rdf.model.StmtIterator;
+import com.hp.hpl.jena.update.GraphStore;
+import com.hp.hpl.jena.update.GraphStoreFactory;
+import com.hp.hpl.jena.update.UpdateAction;
+import com.hp.hpl.jena.update.UpdateFactory;
+import com.hp.hpl.jena.update.UpdateRequest;
+import com.hp.hpl.jena.util.FileManager;
+import com.hp.hpl.jena.vocabulary.RDF;
+
+/**
+ * Copyright 2010 Bernhard Haslhofer 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
+
+/**
+ * SKOSEngine Implementation for Lucene. Each SKOS concept is stored/indexed as a Lucene document. All labels are converted to lowercase.
+ */
+public class SKOSEngineImpl implements SKOSEngine {
+
+    private final static Logger logger = Logger.getLogger(SKOSEngineImpl.class.getName());
+
+    /**
+     * Records the total number of matches
+     */
+    public static class AllDocCollector extends SimpleCollector {
+
+        private final List<Integer> docs = new ArrayList<>();
+        private int base;
+
+        @Override
+        public void setScorer(Scorer scorer) throws IOException {
+        }
+
+        @Override
+        public void collect(int doc) throws IOException {
+            docs.add(doc + base);
+        }
+
+        @Override
+        protected void doSetNextReader(LeafReaderContext context) throws IOException {
+            base = context.docBase;
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
+
+        public List<Integer> getDocs() {
+            return docs;
+        }
+    }
+
+    /*
+     * Static fields used in the Lucene Index
+     */
+    private static final String FIELD_URI = "uri";
+    private static final String FIELD_PREF_LABEL = "pref";
+    private static final String FIELD_ALT_LABEL = "alt";
+    private static final String FIELD_HIDDEN_LABEL = "hidden";
+    private static final String FIELD_BROADER = "broader";
+    private static final String FIELD_NARROWER = "narrower";
+    private static final String FIELD_BROADER_TRANSITIVE = "broaderTransitive";
+    private static final String FIELD_NARROWER_TRANSITIVE = "narrowerTransitive";
+    private static final String FIELD_RELATED = "related";
+    /**
+     * The input SKOS model
+     */
+    private Model skosModel;
+    /**
+     * The location of the concept index
+     */
+    private Directory indexDir;
+    /**
+     * Provides access to the index
+     */
+    private IndexSearcher searcher;
+    /**
+     * The languages to be considered when returning labels. If NULL, all languages are supported
+     */
+    private Set<String> languages;
+    /**
+     * The analyzer used during indexing of / querying for concepts
+     * <p/>
+     * SimpleAnalyzer = LetterTokenizer + LowerCaseFilter
+     */
+    private final Analyzer analyzer;
+
+    /**
+     * This constructor loads the SKOS model from a given InputStream using the given serialization language parameter, which must be either N3, RDF/XML, or TURTLE.
+     *
+     * @param inputStream the input stream
+     * @param lang the serialization language
+     * @throws IOException if the model cannot be loaded
+     */
+    public SKOSEngineImpl(InputStream inputStream, String lang) throws IOException {
+        if (!("N3".equals(lang) || "RDF/XML".equals(lang) || "TURTLE".equals(lang))) {
+            throw new IOException("Invalid RDF serialization format");
+        }
+        this.analyzer = new SimpleAnalyzer();
+        this.skosModel = ModelFactory.createDefaultModel();
+        skosModel.read(inputStream, null, lang);
+        indexDir = new RAMDirectory();
+        entailSKOSModel();
+        indexSKOSModel();
+        searcher = new IndexSearcher(DirectoryReader.open(indexDir));
+    }
+
+    /**
+     * This constructor loads the SKOS model from a given filename or URI, starts the indexing process and sets up the index searcher.
+     *
+     * @param indexPath index path
+     * @param filenameOrURI file name or URI
+     * @param languages the languages to be considered
+     * @throws IOException if indexing SKOS model fails
+     */
+    public SKOSEngineImpl(String indexPath, String filenameOrURI, List<String> languages) throws IOException {
+        this.analyzer = new SimpleAnalyzer();
+        String langSig = "";
+        if (languages != null) {
+            this.languages = new TreeSet<>(languages);
+            if (!this.languages.isEmpty()) {
+                langSig = "-" + join(this.languages.iterator(), '-');
+            }
+        }
+        String name = getName(filenameOrURI);
+        File dir = new File(indexPath + name + langSig);
+        this.indexDir = FSDirectory.open(dir.toPath());
+        if (filenameOrURI != null) {
+            FileManager fileManager = new FileManager();
+            fileManager.addLocatorFile();
+            fileManager.addLocatorURL();
+            fileManager.addLocatorClassLoader(SKOSEngineImpl.class.getClassLoader());
+            if (getExtension(filenameOrURI).equals("zip")) {
+                fileManager.addLocatorZip(filenameOrURI);
+                filenameOrURI = getBaseName(filenameOrURI);
+            }
+            File inputFile = new File(filenameOrURI);
+            Path inputPath = Paths.get(inputFile.getParent(), inputFile.getName());
+            skosModel = fileManager.loadModel(inputPath.toUri().toString());
+            entailSKOSModel();
+            indexSKOSModel();
+            searcher = new IndexSearcher(DirectoryReader.open(indexDir));
+        }
+    }
+
+    /**
+     * This constructor loads the SKOS model from a given InputStream using the given serialization language parameter, which must be either N3, RDF/XML, or TURTLE.
+     *
+     * @param inputStream the input stream
+     * @param format the serialization language
+     * @param languages the languages
+     * @throws IOException if the model cannot be loaded
+     */
+    public SKOSEngineImpl(InputStream inputStream, String format, List<String> languages) throws IOException {
+        if (!("N3".equals(format) || "RDF/XML".equals(format) || "TURTLE".equals(format))) {
+            throw new IOException("Invalid RDF serialization format");
+        }
+        if (languages != null) {
+            this.languages = new TreeSet<>(languages);
+        }
+        analyzer = new SimpleAnalyzer();
+        skosModel = ModelFactory.createDefaultModel();
+        skosModel.read(inputStream, null, format);
+        indexDir = new RAMDirectory();
+        entailSKOSModel();
+        indexSKOSModel();
+        searcher = new IndexSearcher(DirectoryReader.open(indexDir));
+    }
+
+    private void entailSKOSModel() {
+        GraphStore graphStore = GraphStoreFactory.create(skosModel);
+        String sparqlQuery = "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n" + "PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" + "INSERT { ?subject rdf:type skos:Concept }\n" + "WHERE {\n" + "{ ?subject skos:prefLabel ?text } UNION\n" + "{ ?subject skos:altLabel ?text } UNION\n" + "{ ?subject skos:hiddenLabel ?text }\n" + "}";
+        UpdateRequest request = UpdateFactory.create(sparqlQuery);
+        UpdateAction.execute(request, graphStore);
+    }
+
+    /**
+     * Creates lucene documents from SKOS concept. In order to allow language restrictions, one document per language is created.
+     */
+    private Document createDocumentsFromConcept(Resource skos_concept) {
+        Document conceptDoc = new Document();
+        String conceptURI = skos_concept.getURI();
+        Field uriField = new Field(FIELD_URI, conceptURI, StringField.TYPE_STORED);
+        conceptDoc.add(uriField);
+        // store the preferred lexical labels
+        indexAnnotation(skos_concept, conceptDoc, SKOS.prefLabel, FIELD_PREF_LABEL);
+        // store the alternative lexical labels
+        indexAnnotation(skos_concept, conceptDoc, SKOS.altLabel, FIELD_ALT_LABEL);
+        // store the hidden lexical labels
+        indexAnnotation(skos_concept, conceptDoc, SKOS.hiddenLabel, FIELD_HIDDEN_LABEL);
+        // store the URIs of the broader concepts
+        indexObject(skos_concept, conceptDoc, SKOS.broader, FIELD_BROADER);
+        // store the URIs of the broader transitive concepts
+        indexObject(skos_concept, conceptDoc, SKOS.broaderTransitive, FIELD_BROADER_TRANSITIVE);
+        // store the URIs of the narrower concepts
+        indexObject(skos_concept, conceptDoc, SKOS.narrower, FIELD_NARROWER);
+        // store the URIs of the narrower transitive concepts
+        indexObject(skos_concept, conceptDoc, SKOS.narrowerTransitive, FIELD_NARROWER_TRANSITIVE);
+        // store the URIs of the related concepts
+        indexObject(skos_concept, conceptDoc, SKOS.related, FIELD_RELATED);
+        return conceptDoc;
+    }
+
+    @Override
+    public Collection<String> getAltLabels(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_ALT_LABEL);
+    }
+
+    @Override
+    public Collection<String> getAltTerms(String label) throws IOException {
+        Set<String> result = new HashSet<>();
+        // convert the query to lower-case
+        String queryString = label.toLowerCase(Locale.ROOT);
+        try {
+            Collection<String> conceptURIs = getConcepts(queryString);
+            if (conceptURIs != null) {
+                for (String conceptURI : conceptURIs) {
+                    Collection<String> altLabels = getAltLabels(conceptURI);
+                    if (altLabels != null) {
+                        result.addAll(altLabels);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+        return result;
+    }
+
+    @Override
+    public Collection<String> getHiddenLabels(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_HIDDEN_LABEL);
+    }
+
+    @Override
+    public Collection<String> getBroaderConcepts(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_BROADER);
+    }
+
+    @Override
+    public Collection<String> getBroaderLabels(String conceptURI) throws IOException {
+        return getLabels(conceptURI, FIELD_BROADER);
+    }
+
+    @Override
+    public Collection<String> getBroaderTransitiveConcepts(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_BROADER_TRANSITIVE);
+    }
+
+    @Override
+    public Collection<String> getBroaderTransitiveLabels(String conceptURI) throws IOException {
+        return getLabels(conceptURI, FIELD_BROADER_TRANSITIVE);
+    }
+
+    @Override
+    public Collection<String> getConcepts(String label) throws IOException {
+        Set<String> concepts = new HashSet<>();
+        // convert the query to lower-case
+        String queryString = label.toLowerCase(Locale.ROOT);
+        AllDocCollector collector = new AllDocCollector();
+        DisjunctionMaxQuery query = new DisjunctionMaxQuery(0.0f);
+        query.add(new TermQuery(new Term(FIELD_PREF_LABEL, queryString)));
+        query.add(new TermQuery(new Term(FIELD_ALT_LABEL, queryString)));
+        query.add(new TermQuery(new Term(FIELD_HIDDEN_LABEL, queryString)));
+        searcher.search(query, collector);
+        for (Integer hit : collector.getDocs()) {
+            Document doc = searcher.doc(hit);
+            String conceptURI = doc.getValues(FIELD_URI)[0];
+            concepts.add(conceptURI);
+        }
+        return concepts;
+    }
+
+    private Collection<String> getLabels(String conceptURI, String field) throws IOException {
+        Set<String> labels = new HashSet<>();
+        Collection<String> concepts = readConceptFieldValues(conceptURI, field);
+        if (concepts != null) {
+            for (String aConceptURI : concepts) {
+                labels.addAll(getPrefLabels(aConceptURI));
+                labels.addAll(getAltLabels(aConceptURI));
+            }
+        }
+        return labels;
+    }
+
+    @Override
+    public Collection<String> getNarrowerConcepts(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_NARROWER);
+    }
+
+    @Override
+    public Collection<String> getNarrowerLabels(String conceptURI) throws IOException {
+        return getLabels(conceptURI, FIELD_NARROWER);
+    }
+
+    @Override
+    public Collection<String> getNarrowerTransitiveConcepts(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_NARROWER_TRANSITIVE);
+    }
+
+    @Override
+    public Collection<String> getNarrowerTransitiveLabels(String conceptURI) throws IOException {
+        return getLabels(conceptURI, FIELD_NARROWER_TRANSITIVE);
+    }
+
+    @Override
+    public Collection<String> getPrefLabels(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_PREF_LABEL);
+    }
+
+    @Override
+    public Collection<String> getRelatedConcepts(String conceptURI) throws IOException {
+        return readConceptFieldValues(conceptURI, FIELD_RELATED);
+    }
+
+    @Override
+    public Collection<String> getRelatedLabels(String conceptURI) throws IOException {
+        return getLabels(conceptURI, FIELD_RELATED);
+    }
+
+    private void indexAnnotation(Resource skos_concept, Document conceptDoc, AnnotationProperty property, String field) {
+        StmtIterator stmt_iter = skos_concept.listProperties(property);
+        while (stmt_iter.hasNext()) {
+            Literal labelLiteral = stmt_iter.nextStatement().getObject().as(Literal.class);
+            String label = labelLiteral.getLexicalForm();
+            String labelLang = labelLiteral.getLanguage();
+            if (this.languages != null && !this.languages.isEmpty() && !this.languages.contains(labelLang)) {
+                continue;
+            }
+            // converting label to lower-case
+            label = label.toLowerCase(Locale.ROOT);
+            Field labelField = new Field(field, label, StringField.TYPE_STORED);
+            conceptDoc.add(labelField);
+        }
+    }
+
+    private void indexObject(Resource skos_concept, Document conceptDoc, ObjectProperty property, String field) {
+        StmtIterator stmt_iter = skos_concept.listProperties(property);
+        while (stmt_iter.hasNext()) {
+            RDFNode concept = stmt_iter.nextStatement().getObject();
+            if (!concept.canAs(Resource.class)) {
+                logger.warn("Error when indexing relationship of concept " + skos_concept.getURI() + " .");
+                continue;
+            }
+            Resource resource = concept.as(Resource.class);
+            Field conceptField = new Field(field, resource.getURI(), TextField.TYPE_STORED);
+            conceptDoc.add(conceptField);
+        }
+    }
+
+    /**
+     * Creates the synonym index
+     *
+     * @throws IOException
+     */
+    private void indexSKOSModel() throws IOException {
+        IndexWriterConfig cfg = new IndexWriterConfig(analyzer);
+        IndexWriter writer = new IndexWriter(indexDir, cfg);
+        writer.getConfig().setRAMBufferSizeMB(48);
+        /* iterate SKOS concepts, create Lucene docs and add them to the index */
+        ResIterator concept_iter = skosModel.listResourcesWithProperty(RDF.type, SKOS.Concept);
+        while (concept_iter.hasNext()) {
+            Resource skos_concept = concept_iter.next();
+            Document concept_doc = createDocumentsFromConcept(skos_concept);
+            writer.addDocument(concept_doc);
+        }
+        writer.close();
+    }
+
+    /**
+     * Returns the values of a given field for a given concept
+     */
+    private Collection<String> readConceptFieldValues(String conceptURI, String field) throws IOException {
+        Query query = new TermQuery(new Term(FIELD_URI, conceptURI));
+        TopDocs docs = searcher.search(query, 1);
+        ScoreDoc[] results = docs.scoreDocs;
+        if (results.length != 1) {
+            logger.warn("Unknown concept " + conceptURI);
+            return null;
+        }
+        Document conceptDoc = searcher.doc(results[0].doc);
+        return Arrays.asList(conceptDoc.getValues(field));
+    }
+
+    private String join(Iterator iterator, char separator) {
+        // handle null, zero and one elements before building a buffer
+        if (iterator == null) {
+            return null;
+        }
+        if (!iterator.hasNext()) {
+            return "";
+        }
+        Object first = iterator.next();
+        if (!iterator.hasNext()) {
+            return first == null ? "" : first.toString();
+        }
+        // two or more elements
+        StringBuilder buf = new StringBuilder();
+        if (first != null) {
+            buf.append(first);
+        }
+        while (iterator.hasNext()) {
+            buf.append(separator);
+            Object obj = iterator.next();
+            if (obj != null) {
+                buf.append(obj);
+            }
+        }
+        return buf.toString();
+    }
+
+    private static final char UNIX_SEPARATOR = '/';
+    private static final char WINDOWS_SEPARATOR = '\\';
+
+    private String getName(String filename) {
+        if (filename == null) {
+            return null;
+        }
+        int index = indexOfLastSeparator(filename);
+        return filename.substring(index + 1);
+    }
+
+    private int indexOfLastSeparator(String filename) {
+        if (filename == null) {
+            return -1;
+        }
+        int lastUnixPos = filename.lastIndexOf(UNIX_SEPARATOR);
+        int lastWindowsPos = filename.lastIndexOf(WINDOWS_SEPARATOR);
+        return Math.max(lastUnixPos, lastWindowsPos);
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null) {
+            return null;
+        }
+        int index = indexOfExtension(filename);
+        if (index == -1) {
+            return "";
+        } else {
+            return filename.substring(index + 1);
+        }
+    }
+
+    private int indexOfExtension(String filename) {
+        if (filename == null) {
+            return -1;
+        }
+        int extensionPos = filename.lastIndexOf(EXTENSION_SEPARATOR);
+        int lastSeparator = indexOfLastSeparator(filename);
+        return (lastSeparator > extensionPos ? -1 : extensionPos);
+    }
+
+    public static final char EXTENSION_SEPARATOR = '.';
+
+    private String getBaseName(String filename) {
+        return removeExtension(getName(filename));
+    }
+
+    private String removeExtension(String filename) {
+        if (filename == null) {
+            return null;
+        }
+        int index = indexOfExtension(filename);
+        if (index == -1) {
+            return filename;
+        } else {
+            return filename.substring(0, index);
+        }
+    }
+}

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/queryparser/flexible/standard/SKOSStandardQueryParser.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/queryparser/flexible/standard/SKOSStandardQueryParser.java
@@ -24,7 +24,7 @@ import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessor
 import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
 import org.apache.lucene.queryparser.flexible.standard.processors.AnalyzerQueryNodeProcessor;
 
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
 import at.ac.univie.mminf.luceneSKOS.queryparser.flexible.standard.processors.SKOSQueryNodeProcessor;
 
 public class SKOSStandardQueryParser extends StandardQueryParser {

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/queryparser/flexible/standard/processors/SKOSQueryNodeProcessor.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/queryparser/flexible/standard/processors/SKOSQueryNodeProcessor.java
@@ -46,8 +46,8 @@ import org.apache.lucene.queryparser.flexible.standard.nodes.RegexpQueryNode;
 import org.apache.lucene.queryparser.flexible.standard.nodes.StandardBooleanQueryNode;
 import org.apache.lucene.queryparser.flexible.standard.nodes.WildcardQueryNode;
 
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
 
 /**
  * This processor verifies if {@link ConfigurationKeys#ANALYZER}

--- a/src/main/java/at/ac/univie/mminf/luceneSKOS/solr/SKOSFilterFactory.java
+++ b/src/main/java/at/ac/univie/mminf/luceneSKOS/solr/SKOSFilterFactory.java
@@ -1,5 +1,20 @@
 package at.ac.univie.mminf.luceneSKOS.solr;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.util.ResourceLoader;
+import org.apache.lucene.analysis.util.ResourceLoaderAware;
+import org.apache.lucene.analysis.util.TokenFilterFactory;
+import org.apache.solr.core.SolrResourceLoader;
+
 /**
  * Copyright 2010 Bernhard Haslhofer 
  *
@@ -16,114 +31,92 @@ package at.ac.univie.mminf.luceneSKOS.solr;
  * limitations under the License.
  */
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.analysis.util.ResourceLoader;
-import org.apache.lucene.analysis.util.ResourceLoaderAware;
-import org.apache.lucene.analysis.util.TokenFilterFactory;
-import org.apache.solr.core.SolrResourceLoader;
-
 import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer.ExpansionType;
 import at.ac.univie.mminf.luceneSKOS.analysis.SKOSLabelFilter;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
 import at.ac.univie.mminf.luceneSKOS.analysis.SKOSURIFilter;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute.SKOSType;
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngine;
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngineFactory;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngineFactory;
 
 /**
  * A factory for plugging SKOS filters into Apache Solr
  */
 public class SKOSFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
-  private String skosFile;
-  private String expansionTypeString;
-  private String bufferSizeString;
-  private String typeString;
-  private String languageString;
-  private String indexPath;
-  private ExpansionType expansionType;
-  private SKOSType[] type;
-  private SKOSEngine skosEngine;
-  private int bufferSize;
-  
-  
-  public SKOSFilterFactory(Map<String,String> args) {
-    super(args);
-    skosFile = require(args, "skosFile");
-    expansionTypeString = require(args, "expansionType");
-    bufferSizeString = get(args, "bufferSize");
-    typeString = get(args, "type");
-    languageString = get(args, "language");
-    indexPath = get(args, "bufferSize");
-    
-    System.out.println("Passed arguments: " + skosFile + " Type: "
-        + expansionTypeString + " bufferSize: "
-        + (bufferSizeString != null ? bufferSizeString : "Default")
-        + " language: " + (languageString != null ? languageString : "All")
-        + " type: " + (typeString != null ? typeString : "Default"));
-  }
-  
-  @Override
-  public void inform(ResourceLoader loader) {    
-    try {
-      if (skosFile.endsWith(".n3") || skosFile.endsWith(".rdf")
-          || skosFile.endsWith(".ttl") || skosFile.endsWith(".zip")) {
-        skosEngine = SKOSEngineFactory.getSKOSEngine(
-            indexPath != null ? indexPath : "",
-            ((SolrResourceLoader)loader) .getConfigDir() + skosFile,
-            languageString != null ? languageString.split(" ") : null);
-      } else {
-        throw new IOException(
-            "Allowed file suffixes are: .n3 (N3), .rdf (RDF/XML), .ttl (TURTLE) and .zip (ZIP)");
-      }
-      
-    } catch (IOException e) {
-      throw new RuntimeException("Could not instantiate SKOS engine", e);
+
+    private final static Logger logger = Logger.getLogger(SKOSFilterFactory.class.getName());
+
+    private String skosFile;
+    private String expansionTypeString;
+    private String bufferSizeString;
+    private String typeString;
+    private String languageString;
+    private String indexPath;
+    private ExpansionType expansionType;
+    private List<SKOSType> type;
+    private SKOSEngine skosEngine;
+    private int bufferSize;
+
+    public SKOSFilterFactory(Map<String, String> args) {
+        super(args);
+        skosFile = require(args, "skosFile");
+        expansionTypeString = require(args, "expansionType");
+        bufferSizeString = get(args, "bufferSize");
+        typeString = get(args, "type");
+        languageString = get(args, "language");
+        indexPath = get(args, "indexPath");
+
+        logger.info("Passed arguments: " + skosFile + " Type: " + expansionTypeString + " bufferSize: " + (bufferSizeString != null ? bufferSizeString : "Default") + " language: " + (languageString != null ? languageString : "All") + " type: " + (typeString != null ? typeString : "Default"));
     }
-    
-    if (expansionTypeString.equalsIgnoreCase(ExpansionType.URI.toString())) {
-      expansionType = ExpansionType.URI;
-    } else if (expansionTypeString.equalsIgnoreCase(ExpansionType.LABEL
-        .toString())) {
-      expansionType = ExpansionType.LABEL;
-    } else {
-      throw new IllegalArgumentException(
-          "The property 'expansionType' must be either URI or LABEL");
-    }
-    
-    if (bufferSizeString != null) {
-      bufferSize = Integer.parseInt(bufferSizeString);
-      if (bufferSize < 1) {
-        throw new IllegalArgumentException(
-            "The property 'bufferSize' must be a positive (smallish) integer");
-      }
-    }
-    
-    if (typeString != null) {
-      List<SKOSType> types = new ArrayList<SKOSType>();
-      for (String s : typeString.split(" ")) {
-        SKOSType st = SKOSType.valueOf(s.toUpperCase());
-        if (st != null) {
-          types.add(st);
+
+    @Override
+    public void inform(ResourceLoader loader) {
+        try {
+            if (skosFile.endsWith(".n3") || skosFile.endsWith(".rdf") || skosFile.endsWith(".ttl") || skosFile.endsWith(".zip")) {
+                skosEngine = SKOSEngineFactory.getSKOSEngine(indexPath != null ? indexPath : "", ((SolrResourceLoader) loader).getConfigDir() + skosFile, languageString != null ? Arrays.asList(languageString.split(" ")) : null);
+            } else {
+                throw new IOException("Allowed file suffixes are: .n3 (N3), .rdf (RDF/XML), .ttl (TURTLE) and .zip (ZIP)");
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("Could not instantiate SKOS engine", e);
         }
-      }
-      type = types.toArray(new SKOSType[types.size()]);
+
+        if (expansionTypeString.equalsIgnoreCase(ExpansionType.URI.toString())) {
+            expansionType = ExpansionType.URI;
+        } else if (expansionTypeString.equalsIgnoreCase(ExpansionType.LABEL.toString())) {
+            expansionType = ExpansionType.LABEL;
+        } else {
+            throw new IllegalArgumentException("The property 'expansionType' must be either URI or LABEL");
+        }
+
+        if (bufferSizeString != null) {
+            bufferSize = Integer.parseInt(bufferSizeString);
+            if (bufferSize < 1) {
+                throw new IllegalArgumentException("The property 'bufferSize' must be a positive (smallish) integer");
+            }
+        }
+
+        if (typeString != null) {
+            List<SKOSType> types = new ArrayList<>();
+            for (String s : typeString.split(" ")) {
+                SKOSType st = SKOSType.valueOf(s.toUpperCase(Locale.ROOT));
+                if (st != null) {
+                    types.add(st);
+                }
+            }
+            type = types;
+        }
     }
-  }
-  
-  @Override
-  public TokenStream create(TokenStream input) {
-    
-    if (expansionType.equals(ExpansionType.LABEL)) {
-      return new SKOSLabelFilter(input, skosEngine, new StandardAnalyzer(), bufferSize, type);
-      
-    } else {
-      return new SKOSURIFilter(input, skosEngine, new StandardAnalyzer(), type);
+
+    @Override
+    public TokenStream create(TokenStream input) {
+
+        if (expansionType.equals(ExpansionType.LABEL)) {
+            return new SKOSLabelFilter(input, skosEngine, new StandardAnalyzer(), bufferSize, type);
+
+        } else {
+            return new SKOSURIFilter(input, skosEngine, new StandardAnalyzer(), type);
+        }
+
     }
-    
-  }
 }

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/skos/engine/mock/SKOSEngineMock.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/skos/engine/mock/SKOSEngineMock.java
@@ -16,199 +16,197 @@ package at.ac.univie.mminf.luceneSKOS.skos.engine.mock;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngine;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
 
-import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * A mock that simulates the behavior of a SKOS engine for testing purposes
  */
 public class SKOSEngineMock implements SKOSEngine {
 
-  /**
-   * A data structure holding a SKOS Model
-   */
-  private Map<String, Map<SKOSType, List<String>>> conceptMap = new HashMap<>();
-  /**
-   * Stores the maximum number of terms contained in a prefLabel
-   */
-  private int maxPrefLabelTerms = -1;
+    /**
+     * A data structure holding a SKOS Model
+     */
+    private Map<String, Map<SKOSType, List<String>>> conceptMap = new HashMap<>();
+    /**
+     * Stores the maximum number of terms contained in a prefLabel
+     */
+    private int maxPrefLabelTerms = -1;
 
-  /**
-   * Method for feeding mock with data
-   *
-   * @param conceptURI the conecpt URI
-   * @param type       the type
-   * @param values     the values
-   */
-  public void addEntry(String conceptURI, SKOSType type, String... values) {
-    if (!conceptMap.containsKey(conceptURI)) {
-      conceptMap.put(conceptURI, new HashMap<SKOSType, List<String>>());
-    }
-    Map<SKOSType, List<String>> entryMap = conceptMap.get(conceptURI);
-    if (!entryMap.containsKey(type)) {
-      entryMap.put(type, new ArrayList<String>());
-    }
-    List<String> entries = entryMap.get(type);
-    for (String value : values) {
-      entries.add(value.toLowerCase());
-      // check for longest prefLabel
-      if (type.equals(SKOSType.PREF)) {
-        int noTerms = countLabelTerms(value);
-        if (maxPrefLabelTerms < noTerms) {
-          maxPrefLabelTerms = noTerms;
+    /**
+     * Method for feeding mock with data
+     *
+     * @param conceptURI the conecpt URI
+     * @param type the type
+     * @param values the values
+     */
+    public void addEntry(String conceptURI, SKOSType type, String... values) {
+        if (!conceptMap.containsKey(conceptURI)) {
+            conceptMap.put(conceptURI, new HashMap<SKOSType, List<String>>());
         }
-      }
+        Map<SKOSType, List<String>> entryMap = conceptMap.get(conceptURI);
+        if (!entryMap.containsKey(type)) {
+            entryMap.put(type, new ArrayList<String>());
+        }
+        List<String> entries = entryMap.get(type);
+        for (String value : values) {
+            entries.add(value.toLowerCase(Locale.ROOT));
+            // check for longest prefLabel
+            if (type.equals(SKOSType.PREF)) {
+                int noTerms = countLabelTerms(value);
+                if (maxPrefLabelTerms < noTerms) {
+                    maxPrefLabelTerms = noTerms;
+                }
+            }
+        }
     }
-  }
 
-  /**
-   * Returns the number of (whitespace separated) terms contained in a label
-   */
-  private int countLabelTerms(String label) {
-    return label.split(" ").length;
-  }
-
-  @Override
-  public String[] getAltLabels(String conceptURI) throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.ALT);
-  }
-
-  @Override
-  public String[] getAltTerms(String label) throws IOException {
-    List<String> altTerms = new ArrayList<>();
-    // convert the query to lower-case
-    String queryString = label.toLowerCase();
-    String[] conceptURIs = getConcepts(queryString);
-    if (conceptURIs == null) {
-      return null;
+    /**
+     * Returns the number of (whitespace separated) terms contained in a label
+     */
+    private int countLabelTerms(String label) {
+        return label.split(" ").length;
     }
-    for (String conceptURI : conceptURIs) {
-      String[] altLabels = getAltLabels(conceptURI);
-      if (altLabels != null) {
-        altTerms.addAll(Arrays.asList(altLabels));
-      }
+
+    @Override
+    public List<String> getAltLabels(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.ALT);
     }
-    return altTerms.toArray(new String[altTerms.size()]);
-  }
 
-  @Override
-  public String[] getHiddenLabels(String conceptURI) throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.HIDDEN);
-  }
-
-  @Override
-  public String[] getBroaderConcepts(String conceptURI) throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.BROADER);
-  }
-
-  @Override
-  public String[] getBroaderLabels(String conceptURI) throws IOException {
-    return getLabels(conceptURI, SKOSType.BROADER);
-  }
-
-  @Override
-  public String[] getBroaderTransitiveConcepts(String conceptURI)
-      throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.BROADERTRANSITIVE);
-  }
-
-  @Override
-  public String[] getBroaderTransitiveLabels(String conceptURI)
-      throws IOException {
-    return getLabels(conceptURI, SKOSType.BROADERTRANSITIVE);
-  }
-
-  @Override
-  public String[] getConcepts(String label) throws IOException {
-    String queryString = label.toLowerCase();
-    List<String> conceptURIs = new ArrayList<>();
-    for (String conceptURI : conceptMap.keySet()) {
-      Map<SKOSType, List<String>> entryMap = conceptMap.get(conceptURI);
-      List<String> prefLabels = entryMap.get(SKOSType.PREF);
-      if (prefLabels != null && prefLabels.contains(queryString)) {
-        conceptURIs.add(conceptURI);
-      }
-      List<String> altLabels = entryMap.get(SKOSType.ALT);
-      if (altLabels != null && altLabels.contains(queryString)) {
-        conceptURIs.add(conceptURI);
-      }
-      List<String> hiddenLabels = entryMap.get(SKOSType.HIDDEN);
-      if (hiddenLabels != null && hiddenLabels.contains(queryString)) {
-        conceptURIs.add(conceptURI);
-      }
+    @Override
+    public List<String> getAltTerms(String label) {
+        List<String> altTerms = new ArrayList<>();
+        // convert the query to lower-case
+        String queryString = label.toLowerCase(Locale.ROOT);
+        List<String> conceptURIs = getConcepts(queryString);
+        if (conceptURIs == null) {
+            return null;
+        }
+        for (String conceptURI : conceptURIs) {
+            List<String> altLabels = getAltLabels(conceptURI);
+            if (altLabels != null) {
+                altTerms.addAll(altLabels);
+            }
+        }
+        return altTerms;
     }
-    return conceptURIs.toArray(new String[conceptURIs.size()]);
-  }
 
-  private String[] getLabels(String conceptURI, SKOSType type)
-      throws IOException {
-    String[] concepts = readConceptFieldValues(conceptURI, type);
-    if (concepts == null) {
-      return null;
+    @Override
+    public List<String> getHiddenLabels(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.HIDDEN);
     }
-    List<String> labels = new ArrayList<>();
-    for (String aConcept : concepts) {
-      String[] prefLabels = getPrefLabels(aConcept);
-      if (prefLabels != null) {
-        labels.addAll(Arrays.asList(prefLabels));
-      }
-      String[] altLabels = getAltLabels(aConcept);
-      if (altLabels != null) {
-        labels.addAll(Arrays.asList(altLabels));
-      }
+
+    @Override
+    public List<String> getBroaderConcepts(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.BROADER);
     }
-    return labels.toArray(new String[labels.size()]);
-  }
 
-  @Override
-  public String[] getNarrowerConcepts(String conceptURI) throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.NARROWER);
-  }
-
-  @Override
-  public String[] getNarrowerLabels(String conceptURI) throws IOException {
-    return getLabels(conceptURI, SKOSType.NARROWER);
-  }
-
-  @Override
-  public String[] getNarrowerTransitiveConcepts(String conceptURI)
-      throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.NARROWERTRANSITIVE);
-  }
-
-  @Override
-  public String[] getNarrowerTransitiveLabels(String conceptURI)
-      throws IOException {
-    return getLabels(conceptURI, SKOSType.NARROWERTRANSITIVE);
-  }
-
-  @Override
-  public String[] getPrefLabels(String conceptURI) throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.PREF);
-  }
-
-  @Override
-  public String[] getRelatedConcepts(String conceptURI) throws IOException {
-    return readConceptFieldValues(conceptURI, SKOSType.RELATED);
-  }
-
-  @Override
-  public String[] getRelatedLabels(String conceptURI) throws IOException {
-    return getLabels(conceptURI, SKOSType.RELATED);
-  }
-
-  /**
-   * Returns the values of a given field for a given concept
-   */
-  private String[] readConceptFieldValues(String conceptURI, SKOSType type)
-      throws IOException {
-    List<String> labels = conceptMap.get(conceptURI).get(type);
-    if (labels != null) {
-      return labels.toArray(new String[labels.size()]);
+    @Override
+    public List<String> getBroaderLabels(String conceptURI) {
+        return getLabels(conceptURI, SKOSType.BROADER);
     }
-    return new String[0];
-  }
+
+    @Override
+    public List<String> getBroaderTransitiveConcepts(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.BROADERTRANSITIVE);
+    }
+
+    @Override
+    public List<String> getBroaderTransitiveLabels(String conceptURI) {
+        return getLabels(conceptURI, SKOSType.BROADERTRANSITIVE);
+    }
+
+    @Override
+    public List<String> getConcepts(String label) {
+        String queryString = label.toLowerCase(Locale.ROOT);
+        List<String> conceptURIs = new ArrayList<>();
+        for (String conceptURI : conceptMap.keySet()) {
+            Map<SKOSType, List<String>> entryMap = conceptMap.get(conceptURI);
+            List<String> prefLabels = entryMap.get(SKOSType.PREF);
+            if (prefLabels != null && prefLabels.contains(queryString)) {
+                conceptURIs.add(conceptURI);
+            }
+            List<String> altLabels = entryMap.get(SKOSType.ALT);
+            if (altLabels != null && altLabels.contains(queryString)) {
+                conceptURIs.add(conceptURI);
+            }
+            List<String> hiddenLabels = entryMap.get(SKOSType.HIDDEN);
+            if (hiddenLabels != null && hiddenLabels.contains(queryString)) {
+                conceptURIs.add(conceptURI);
+            }
+        }
+        return conceptURIs;
+    }
+
+    private List<String> getLabels(String conceptURI, SKOSType type) {
+        List<String> concepts = readConceptFieldValues(conceptURI, type);
+        if (concepts == null || concepts.isEmpty()) {
+            return null;
+        }
+        List<String> labels = new ArrayList<>();
+        for (String aConcept : concepts) {
+            List<String> prefLabels = getPrefLabels(aConcept);
+            if (prefLabels != null) {
+                labels.addAll(prefLabels);
+            }
+            List<String> altLabels = getAltLabels(aConcept);
+            if (altLabels != null) {
+                labels.addAll(altLabels);
+            }
+        }
+        return labels;
+    }
+
+    @Override
+    public List<String> getNarrowerConcepts(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.NARROWER);
+    }
+
+    @Override
+    public List<String> getNarrowerLabels(String conceptURI) {
+        return getLabels(conceptURI, SKOSType.NARROWER);
+    }
+
+    @Override
+    public List<String> getNarrowerTransitiveConcepts(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.NARROWERTRANSITIVE);
+    }
+
+    @Override
+    public List<String> getNarrowerTransitiveLabels(String conceptURI) {
+        return getLabels(conceptURI, SKOSType.NARROWERTRANSITIVE);
+    }
+
+    @Override
+    public List<String> getPrefLabels(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.PREF);
+    }
+
+    @Override
+    public List<String> getRelatedConcepts(String conceptURI) {
+        return readConceptFieldValues(conceptURI, SKOSType.RELATED);
+    }
+
+    @Override
+    public List<String> getRelatedLabels(String conceptURI) {
+        return getLabels(conceptURI, SKOSType.RELATED);
+    }
+
+    /**
+     * Returns the values of a given field for a given concept
+     */
+    private List<String> readConceptFieldValues(String conceptURI, SKOSType type) {
+        List<String> labels = conceptMap.get(conceptURI).get(type);
+        if (labels != null) {
+            return labels;
+        }
+        return Collections.emptyList();
+    }
 }

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/test/AbstractFilterTest.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/test/AbstractFilterTest.java
@@ -16,78 +16,70 @@ package at.ac.univie.mminf.luceneSKOS.test;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer;
-import at.ac.univie.mminf.luceneSKOS.skos.engine.mock.SKOSEngineMock;
-import at.ac.univie.mminf.luceneSKOS.tokenattributes.SKOSTypeAttribute.SKOSType;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
+
 import org.junit.After;
 import org.junit.Before;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSTypeAttribute.SKOSType;
+import at.ac.univie.mminf.luceneSKOS.skos.engine.mock.SKOSEngineMock;
 
 /**
  * Abstract class containing common code for filter tests
  */
 public abstract class AbstractFilterTest {
 
-  protected IndexSearcher searcher;
+    protected IndexSearcher searcher;
 
-  protected IndexWriter writer;
+    protected IndexWriter writer;
 
-  protected SKOSEngineMock skosEngine;
+    protected SKOSEngineMock skosEngine;
 
-  protected SKOSAnalyzer skosAnalyzer;
+    protected SKOSAnalyzer skosAnalyzer;
 
-  protected Directory directory;
+    protected Directory directory;
 
-  @Before
-  protected void setUp() throws Exception {
+    @Before
+    protected void setUp() throws Exception {
 
-    // adding some test data
-    skosEngine = new SKOSEngineMock();
+        // adding some test data
+        skosEngine = new SKOSEngineMock();
 
-    skosEngine.addEntry("http://example.com/concept/1", SKOSType.PREF, "jumps");
-    skosEngine.addEntry("http://example.com/concept/1", SKOSType.ALT, "leaps",
-        "hops");
+        skosEngine.addEntry("http://example.com/concept/1", SKOSType.PREF, "jumps");
+        skosEngine.addEntry("http://example.com/concept/1", SKOSType.ALT, "leaps", "hops");
 
-    skosEngine.addEntry("http://example.com/concept/2", SKOSType.PREF, "quick");
-    skosEngine.addEntry("http://example.com/concept/2", SKOSType.ALT, "fast",
-        "speedy");
+        skosEngine.addEntry("http://example.com/concept/2", SKOSType.PREF, "quick");
+        skosEngine.addEntry("http://example.com/concept/2", SKOSType.ALT, "fast", "speedy");
 
-    skosEngine.addEntry("http://example.com/concept/3", SKOSType.PREF, "over");
-    skosEngine.addEntry("http://example.com/concept/3", SKOSType.ALT, "above");
+        skosEngine.addEntry("http://example.com/concept/3", SKOSType.PREF, "over");
+        skosEngine.addEntry("http://example.com/concept/3", SKOSType.ALT, "above");
 
-    skosEngine.addEntry("http://example.com/concept/4", SKOSType.PREF, "lazy");
-    skosEngine.addEntry("http://example.com/concept/4", SKOSType.ALT,
-        "apathic", "sluggish");
+        skosEngine.addEntry("http://example.com/concept/4", SKOSType.PREF, "lazy");
+        skosEngine.addEntry("http://example.com/concept/4", SKOSType.ALT, "apathic", "sluggish");
 
-    skosEngine.addEntry("http://example.com/concept/5", SKOSType.PREF, "dog");
-    skosEngine.addEntry("http://example.com/concept/5", SKOSType.ALT, "canine",
-        "pooch");
+        skosEngine.addEntry("http://example.com/concept/5", SKOSType.PREF, "dog");
+        skosEngine.addEntry("http://example.com/concept/5", SKOSType.ALT, "canine", "pooch");
 
-    skosEngine.addEntry("http://example.com/concept/6", SKOSType.PREF,
-        "united nations");
-    skosEngine.addEntry("http://example.com/concept/6", SKOSType.ALT, "UN");
+        skosEngine.addEntry("http://example.com/concept/6", SKOSType.PREF, "united nations");
+        skosEngine.addEntry("http://example.com/concept/6", SKOSType.ALT, "UN");
 
-    skosEngine.addEntry("http://example.com/concept/7", SKOSType.PREF,
-        "lazy dog");
-    skosEngine.addEntry("http://example.com/concept/7", SKOSType.ALT, "Odie");
+        skosEngine.addEntry("http://example.com/concept/7", SKOSType.PREF, "lazy dog");
+        skosEngine.addEntry("http://example.com/concept/7", SKOSType.ALT, "Odie");
 
-    this.directory = new RAMDirectory();
+        this.directory = new RAMDirectory();
 
-  }
-
-  @After
-  public void tearDown() throws Exception {
-
-    if (writer != null) {
-      writer.close();
     }
 
-    if (searcher != null) {
-      searcher.getIndexReader().close();
+    @After
+    public void tearDown() throws Exception {
+        if (writer != null) {
+            writer.close();
+        }
+        if (searcher != null) {
+            searcher.getIndexReader().close();
+        }
     }
-
-  }
 }

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/test/SKOSEngineTest.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/test/SKOSEngineTest.java
@@ -1,5 +1,12 @@
 package at.ac.univie.mminf.luceneSKOS.test;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
 /**
  * Copyright 2010 Bernhard Haslhofer 
  *
@@ -16,101 +23,88 @@ package at.ac.univie.mminf.luceneSKOS.test;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngine;
-import at.ac.univie.mminf.luceneSKOS.skos.engine.SKOSEngineFactory;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngine;
+import at.ac.univie.mminf.luceneSKOS.analysis.engine.SKOSEngineFactory;
 
 /**
  * Tests the functionality of the Lucene-backed SKOS Engine implementation
  */
 public class SKOSEngineTest extends Assert {
 
-  @Test
-  public void testSimpleSKOSSamplesRDFXML() throws IOException {
-    InputStream skosFile = getClass().getResourceAsStream("/skos_samples/simple_test_skos.rdf");
-    SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "RDF/XML");
-    assertEquals(2, skosEngine.getAltTerms("quick").length);
-    assertEquals(1, skosEngine.getAltTerms("over").length);
-  }
+    @Test
+    public void testSimpleSKOSSamplesRDFXML() throws IOException {
+        InputStream skosFile = getClass().getResourceAsStream("/skos_samples/simple_test_skos.rdf");
+        SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "RDF/XML");
+        assertEquals(2, skosEngine.getAltTerms("quick").size());
+        assertEquals(1, skosEngine.getAltTerms("over").size());
+    }
 
-  @Test
-  public void testSimpleSKOSSamplesN3() throws IOException {
-    InputStream skosFile = getClass().getResourceAsStream("/skos_samples/simple_test_skos.rdf");
-    SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "RDF/XML");
-    assertEquals(2, skosEngine.getAltTerms("quick").length);
-    assertEquals(1, skosEngine.getAltTerms("over").length);
-  }
+    @Test
+    public void testSimpleSKOSSamplesN3() throws IOException {
+        InputStream skosFile = getClass().getResourceAsStream("/skos_samples/simple_test_skos.rdf");
+        SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "RDF/XML");
+        assertEquals(2, skosEngine.getAltTerms("quick").size());
+        assertEquals(1, skosEngine.getAltTerms("over").size());
+    }
 
-  /**
-   * Tests retrieval of non-explicitly types SKOS concepts
-   */
-  @Test
-  public void testSimpleSKOSSampleN3NoType() throws IOException {
-    InputStream skosFile = getClass().getResourceAsStream("/skos_samples/simple_test_skos.n3");
-    SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3");
-    assertEquals(2, skosEngine.getAltTerms("sheep").length);
-    assertEquals(2, skosEngine.getAltTerms("kity").length);
-  }
+    @Test
+    public void testSimpleSKOSSampleN3NoType() throws IOException {
+        InputStream skosFile = getClass().getResourceAsStream("/skos_samples/simple_test_skos.n3");
+        SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3");
+        assertEquals(2, skosEngine.getAltTerms("sheep").size());
+        assertEquals(2, skosEngine.getAltTerms("kity").size());
+    }
 
-  @Test
-  public void testSKOSSpecSamples() throws IOException {
-    InputStream skosFile = getClass().getResourceAsStream("/skos_samples/skos_spec_samples.n3");
-    SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3");
-    assertEquals(skosEngine.getAltTerms("animals").length, 3);
-    assertEquals(skosEngine.getAltTerms("Food and Agriculture Organization").length, 1);
-  }
+    @Test
+    public void testSKOSSpecSamples() throws IOException {
+        InputStream skosFile = getClass().getResourceAsStream("/skos_samples/skos_spec_samples.n3");
+        SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3");
+        assertEquals(skosEngine.getAltTerms("animals").size(), 3);
+        assertEquals(skosEngine.getAltTerms("Food and Agriculture Organization").size(), 1);
+    }
 
-  @Test
-  public void testSKOSSpecSamplesWithLanguageRestriction() throws IOException {
-    InputStream skosFile = getClass().getResourceAsStream("/skos_samples/skos_spec_samples.n3");
-    SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3", "en");
-    String[] altTerms = skosEngine.getAltTerms("animals");
-    assertEquals(1, altTerms.length);
-    assertEquals("creatures", altTerms[0]);
-  }
+    @Test
+    public void testSKOSSpecSamplesWithLanguageRestriction() throws IOException {
+        InputStream skosFile = getClass().getResourceAsStream("/skos_samples/skos_spec_samples.n3");
+        SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3", "en");
+        Collection<String> altTerms = skosEngine.getAltTerms("animals");
+        assertEquals(1, altTerms.size());
+        assertEquals("creatures", altTerms.iterator().next());
+    }
 
-  @Test
-  public void testUKATSamples() throws IOException {
-    InputStream skosFile = getClass().getResourceAsStream("/skos_samples/ukat_examples.n3");
-    String conceptURI = "http://www.ukat.org.uk/thesaurus/concept/859";
-    SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3");
-    // testing pref-labels
-    String[] prefLabel = skosEngine.getPrefLabels(conceptURI);
-    assertEquals(1, prefLabel.length);
-    assertEquals("weapons", prefLabel[0]);
-    // testing alt-labels
-    String[] altLabel = skosEngine.getAltLabels(conceptURI);
-    assertEquals(2, altLabel.length);
-    assertTrue(Arrays.asList(altLabel).contains("armaments"));
-    assertTrue(Arrays.asList(altLabel).contains("arms"));
-    // testing broader
-    String[] broader = skosEngine.getBroaderConcepts(conceptURI);
-    assertEquals(1, broader.length);
-    assertEquals("http://www.ukat.org.uk/thesaurus/concept/5060", broader[0]);
-    // testing narrower
-    String[] narrower = skosEngine.getNarrowerConcepts(conceptURI);
-    assertEquals(2, narrower.length);
-    assertTrue(Arrays.asList(narrower).contains(
-        "http://www.ukat.org.uk/thesaurus/concept/18874"));
-    assertTrue(Arrays.asList(narrower).contains(
-        "http://www.ukat.org.uk/thesaurus/concept/7630"));
-    // testing broader labels
-    String[] broaderLabels = skosEngine.getBroaderLabels(conceptURI);
-    assertEquals(3, broaderLabels.length);
-    assertTrue(Arrays.asList(broaderLabels).contains(
-        "military equipment"));
-    assertTrue(Arrays.asList(broaderLabels).contains(
-        "defense equipment and supplies"));
-    assertTrue(Arrays.asList(broaderLabels).contains("ordnance"));
-    // testing narrower labels
-    String[] narrowerLabels = skosEngine.getNarrowerLabels(conceptURI);
-    assertEquals(2, narrowerLabels.length);
-    assertTrue(Arrays.asList(narrowerLabels).contains("ammunition"));
-    assertTrue(Arrays.asList(narrowerLabels).contains("artillery"));
-  }
+    @Test
+    public void testUKATSamples() throws IOException {
+        InputStream skosFile = getClass().getResourceAsStream("/skos_samples/ukat_examples.n3");
+        String conceptURI = "http://www.ukat.org.uk/thesaurus/concept/859";
+        SKOSEngine skosEngine = SKOSEngineFactory.getSKOSEngine(skosFile, "N3");
+        // testing pref-labels
+        Collection<String> prefLabel = skosEngine.getPrefLabels(conceptURI);
+        assertEquals(1, prefLabel.size());
+        assertEquals("weapons", prefLabel.iterator().next());
+        // testing alt-labels
+        Collection<String> altLabel = skosEngine.getAltLabels(conceptURI);
+        assertEquals(2, altLabel.size());
+        assertTrue(altLabel.contains("armaments"));
+        assertTrue(altLabel.contains("arms"));
+        // testing broader
+        Collection<String> broader = skosEngine.getBroaderConcepts(conceptURI);
+        assertEquals(1, broader.size());
+        assertEquals("http://www.ukat.org.uk/thesaurus/concept/5060", broader.iterator().next());
+        // testing narrower
+        Collection<String> narrower = skosEngine.getNarrowerConcepts(conceptURI);
+        assertEquals(2, narrower.size());
+        assertTrue(narrower.contains("http://www.ukat.org.uk/thesaurus/concept/18874"));
+        assertTrue(narrower.contains("http://www.ukat.org.uk/thesaurus/concept/7630"));
+        // testing broader labels
+        Collection<String> broaderLabels = skosEngine.getBroaderLabels(conceptURI);
+        assertEquals(3, broaderLabels.size());
+        assertTrue(broaderLabels.contains("military equipment"));
+        assertTrue(broaderLabels.contains("defense equipment and supplies"));
+        assertTrue(broaderLabels.contains("ordnance"));
+        // testing narrower labels
+        Collection<String> narrowerLabels = skosEngine.getNarrowerLabels(conceptURI);
+        assertEquals(2, narrowerLabels.size());
+        assertTrue(narrowerLabels.contains("ammunition"));
+        assertTrue(narrowerLabels.contains("artillery"));
+    }
 }

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/test/SKOSLabelFilterTest.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/test/SKOSLabelFilterTest.java
@@ -16,7 +16,8 @@ package at.ac.univie.mminf.luceneSKOS.test;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer;
+import java.io.IOException;
+
 import org.apache.lucene.analysis.core.SimpleAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -32,10 +33,10 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer;
 
 import static org.junit.Assert.assertEquals;
 
@@ -44,60 +45,60 @@ import static org.junit.Assert.assertEquals;
  */
 public class SKOSLabelFilterTest extends AbstractFilterTest {
 
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    skosAnalyzer = new SKOSAnalyzer(skosEngine, SKOSAnalyzer.ExpansionType.LABEL);
-    writer = new IndexWriter(directory, new IndexWriterConfig(skosAnalyzer));
-  }
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        skosAnalyzer = new SKOSAnalyzer(skosEngine, SKOSAnalyzer.ExpansionType.LABEL);
+        writer = new IndexWriter(directory, new IndexWriterConfig(skosAnalyzer));
+    }
 
-  @Test
-  public void termQuerySearch() throws IOException {
-    Document doc = new Document();
-    doc.add(new Field("content", "The quick brown fox jumps over the lazy dog", TextField.TYPE_STORED));
-    writer.addDocument(doc);
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
-    TermQuery tq = new TermQuery(new Term("content", "hops"));
-    assertEquals(1, searcher.search(tq, 1).totalHits);
-  }
+    @Test
+    public void termQuerySearch() throws IOException {
+        Document doc = new Document();
+        doc.add(new Field("content", "The quick brown fox jumps over the lazy dog", TextField.TYPE_STORED));
+        writer.addDocument(doc);
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+        TermQuery tq = new TermQuery(new Term("content", "hops"));
+        assertEquals(1, searcher.search(tq, 1).totalHits);
+    }
 
-  @Test
-  public void phraseQuerySearch() throws IOException {
-    Document doc = new Document();
-    doc.add(new Field("content", "The quick brown fox jumps over the lazy dog", TextField.TYPE_STORED));
-    writer.addDocument(doc);
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
-    PhraseQuery.Builder builder = new PhraseQuery.Builder();
-    builder.add(new Term("content", "fox")).add(new Term("content", "hops"));
-    assertEquals(1, searcher.search(builder.build(), 1).totalHits);
-  }
+    @Test
+    public void phraseQuerySearch() throws IOException {
+        Document doc = new Document();
+        doc.add(new Field("content", "The quick brown fox jumps over the lazy dog", TextField.TYPE_STORED));
+        writer.addDocument(doc);
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+        PhraseQuery.Builder builder = new PhraseQuery.Builder();
+        builder.add(new Term("content", "fox")).add(new Term("content", "hops"));
+        assertEquals(1, searcher.search(builder.build(), 1).totalHits);
+    }
 
-  @Test
-  public void queryParserSearch() throws IOException, QueryNodeException {
-    Document doc = new Document();
-    doc.add(new Field("content", "The quick brown fox jumps over the lazy dog", TextField.TYPE_STORED));
-    writer.addDocument(doc);
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
-    Query query = new StandardQueryParser(skosAnalyzer).parse("\"fox jumps\"", "content");
-    assertEquals(1, searcher.search(query, 1).totalHits);
-    assertEquals("content:\"fox (jumps hops leaps)\"", query.toString());
-    assertEquals("org.apache.lucene.search.MultiPhraseQuery", query
-        .getClass().getName());
-    query = new StandardQueryParser(new StandardAnalyzer()).parse("\"fox jumps\"", "content");
-    assertEquals(1, searcher.search(query, 1).totalHits);
-    assertEquals("content:\"fox jumps\"", query.toString());
-    assertEquals("org.apache.lucene.search.PhraseQuery", query.getClass().getName());
-  }
+    @Test
+    public void queryParserSearch() throws IOException, QueryNodeException {
+        Document doc = new Document();
+        doc.add(new Field("content", "The quick brown fox jumps over the lazy dog", TextField.TYPE_STORED));
+        writer.addDocument(doc);
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+        Query query = new StandardQueryParser(skosAnalyzer).parse("\"fox jumps\"", "content");
+        assertEquals(1, searcher.search(query, 1).totalHits);
+        assertEquals("content:\"fox (jumps hops leaps)\"", query.toString());
+        assertEquals("org.apache.lucene.search.MultiPhraseQuery", query
+                .getClass().getName());
+        query = new StandardQueryParser(new StandardAnalyzer()).parse("\"fox jumps\"", "content");
+        assertEquals(1, searcher.search(query, 1).totalHits);
+        assertEquals("content:\"fox jumps\"", query.toString());
+        assertEquals("org.apache.lucene.search.PhraseQuery", query.getClass().getName());
+    }
 
-  @Test
-  public void testTermQuery() throws IOException, QueryNodeException {
-    Document doc = new Document();
-    doc.add(new Field("content", "I work for the united nations", TextField.TYPE_STORED));
-    writer.addDocument(doc);
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
-    StandardQueryParser parser = new StandardQueryParser(new SimpleAnalyzer());
-    Query query = parser.parse("united nations", "content");
-    assertEquals(1, searcher.search(query, 1).totalHits);
-  }
+    @Test
+    public void testTermQuery() throws IOException, QueryNodeException {
+        Document doc = new Document();
+        doc.add(new Field("content", "I work for the united nations", TextField.TYPE_STORED));
+        writer.addDocument(doc);
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+        StandardQueryParser parser = new StandardQueryParser(new SimpleAnalyzer());
+        Query query = parser.parse("united nations", "content");
+        assertEquals(1, searcher.search(query, 1).totalHits);
+    }
 }

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/test/SKOSURIFilterTest.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/test/SKOSURIFilterTest.java
@@ -16,20 +16,24 @@ package at.ac.univie.mminf.luceneSKOS.test;
  * limitations under the License.
  */
 
-import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer;
-import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer.ExpansionType;
+import java.io.IOException;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.TextField;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer;
+import at.ac.univie.mminf.luceneSKOS.analysis.SKOSAnalyzer.ExpansionType;
 
 import static org.junit.Assert.assertEquals;
 
@@ -38,114 +42,68 @@ import static org.junit.Assert.assertEquals;
  */
 public class SKOSURIFilterTest extends AbstractFilterTest {
 
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    skosAnalyzer = new SKOSAnalyzer(skosEngine, ExpansionType.URI);
-    writer = new IndexWriter(directory, new IndexWriterConfig(skosAnalyzer));
-  }
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        skosAnalyzer = new SKOSAnalyzer(skosEngine, ExpansionType.URI);
+        writer = new IndexWriter(directory, new IndexWriterConfig(skosAnalyzer));
+    }
 
-  @Test
-  public void singleUriExpansionWithStoredField() throws CorruptIndexException,
-      IOException {
+    @Test
+    public void singleUriExpansionWithStoredField() throws IOException {
+        Document doc = new Document();
+        doc.add(new Field("subject", "http://example.com/concept/1", TextField.TYPE_STORED));
+        writer.addDocument(doc);
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+        Query query = new TermQuery(new Term("subject", "leaps"));
+        TopDocs results = searcher.search(query, 10);
+        assertEquals(1, results.totalHits);
 
-    Document doc = new Document();
-    doc.add(new Field("subject", "http://example.com/concept/1",
-        TextField.TYPE_STORED));
+        Document indexDoc = searcher.doc(results.scoreDocs[0].doc);
+        String[] fieldValues = indexDoc.getValues("subject");
+        assertEquals(1, fieldValues.length);
+        assertEquals(fieldValues[0], "http://example.com/concept/1");
+    }
 
-    writer.addDocument(doc);
+    @Test
+    public void singleUriExpansionWithUnstoredField() throws IOException {
+        Document doc = new Document();
+        doc.add(new Field("subject", "http://example.com/concept/1", TextField.TYPE_NOT_STORED));
+        writer.addDocument(doc);
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+        Query query = new TermQuery(new Term("subject", "jumps"));
+        TopDocs results = searcher.search(query, 10);
+        assertEquals(1, results.totalHits);
 
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+        Document indexDoc = searcher.doc(results.scoreDocs[0].doc);
+        String[] fieldValues = indexDoc.getValues("subject");
+        assertEquals(0, fieldValues.length);
+    }
 
-    Query query = new TermQuery(new Term("subject", "leaps"));
+    @Test
+    public void multipleURIExpansion() throws IOException {
+        Document doc = new Document();
+        doc.add(new Field("subject", "http://example.com/concept/1", TextField.TYPE_STORED));
+        doc.add(new Field("subject", "http://example.com/concept/2", TextField.TYPE_STORED));
+        writer.addDocument(doc);
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
 
-    TopDocs results = searcher.search(query, 10);
-    assertEquals(1, results.totalHits);
+        // querying for alternative term of concept 1
+        Query query = new TermQuery(new Term("subject", "hops"));
+        TopDocs results = searcher.search(query, 10);
+        assertEquals(1, results.totalHits);
+        Document indexDoc = searcher.doc(results.scoreDocs[0].doc);
+        String[] fieldValues = indexDoc.getValues("subject");
+        assertEquals(2, fieldValues.length);
 
-    Document indexDoc = searcher.doc(results.scoreDocs[0].doc);
+        // querying for alternative term of concept 2
+        query = new TermQuery(new Term("subject", "speedy"));
+        results = searcher.search(query, 10);
+        assertEquals(1, results.totalHits);
 
-    String[] fieldValues = indexDoc.getValues("subject");
-
-    assertEquals(1, fieldValues.length);
-
-    assertEquals(fieldValues[0], "http://example.com/concept/1");
-
-  }
-
-  @Test
-  public void singleUriExpansionWithUnstoredField()
-      throws CorruptIndexException, IOException {
-
-    Document doc = new Document();
-    doc.add(new Field("subject", "http://example.com/concept/1",
-        TextField.TYPE_NOT_STORED));
-
-    writer.addDocument(doc);
-
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
-
-    Query query = new TermQuery(new Term("subject", "jumps"));
-
-    TopDocs results = searcher.search(query, 10);
-    assertEquals(1, results.totalHits);
-
-    Document indexDoc = searcher.doc(results.scoreDocs[0].doc);
-
-    String[] fieldValues = indexDoc.getValues("subject");
-
-    assertEquals(0, fieldValues.length);
-
-  }
-
-  @Test
-  public void multipleURIExpansion() throws IOException {
-
-    Document doc = new Document();
-    doc.add(new Field("subject", "http://example.com/concept/1",
-        TextField.TYPE_STORED));
-    doc.add(new Field("subject", "http://example.com/concept/2",
-        TextField.TYPE_STORED));
-
-    writer.addDocument(doc);
-
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
-
-    // querying for alternative term of concept 1
-    Query query = new TermQuery(new Term("subject", "hops"));
-
-    TopDocs results = searcher.search(query, 10);
-    assertEquals(1, results.totalHits);
-
-    Document indexDoc = searcher.doc(results.scoreDocs[0].doc);
-
-    String[] fieldValues = indexDoc.getValues("subject");
-
-    assertEquals(2, fieldValues.length);
-
-    // querying for alternative term of concept 2
-    query = new TermQuery(new Term("subject", "speedy"));
-
-    results = searcher.search(query, 10);
-    assertEquals(1, results.totalHits);
-
-    indexDoc = searcher.doc(results.scoreDocs[0].doc);
-
-    fieldValues = indexDoc.getValues("subject");
-
-    assertEquals(2, fieldValues.length);
-
-  }
-
-  // @Test
-  public void displayTokensWithURIExpansion() throws IOException {
-
-    String text = "http://example.com/concept/1";
-
-    skosAnalyzer = new SKOSAnalyzer(skosEngine, ExpansionType.URI);
-
-    AnalyzerUtils.displayTokensWithFullDetails(skosAnalyzer, text);
-    // AnalyzerUtils.displayTokensWithPositions(synonymAnalyzer, text);
-
-  }
+        indexDoc = searcher.doc(results.scoreDocs[0].doc);
+        fieldValues = indexDoc.getValues("subject");
+        assertEquals(2, fieldValues.length);
+    }
 }

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/test/termexpansion/AbstractTermExpansionTest.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/test/termexpansion/AbstractTermExpansionTest.java
@@ -69,13 +69,13 @@ public abstract class AbstractTermExpansionTest {
     Document doc = new Document();
     doc.add(new Field("title", "Spearhead", TextField.TYPE_STORED));
     doc.add(new Field("description",
-        "Roman iron spearhead. The spearhead was attached to one end of a wooden shaft..."
-            + "The spear was mainly a thrusting weapon, but could also be thrown. "
-            + "It was the principal weapon of the auxiliary soldier... "
-            + "(second - fourth century, Arbeia Roman Fort).",
-        TextField.TYPE_NOT_STORED));
+            "Roman iron spearhead. The spearhead was attached to one end of a wooden shaft..."
+                    + "The spear was mainly a thrusting weapon, but could also be thrown. "
+                    + "It was the principal weapon of the auxiliary soldier... "
+                    + "(second - fourth century, Arbeia Roman Fort).",
+            TextField.TYPE_NOT_STORED));
     doc.add(new Field("subject", "weapons",
-        TextField.TYPE_NOT_STORED));
+            TextField.TYPE_NOT_STORED));
 
         /* setting up a writer with a default (simple) analyzer */
     writer = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(new SimpleAnalyzer()));
@@ -86,8 +86,8 @@ public abstract class AbstractTermExpansionTest {
         /* defining a query that searches over all fields */
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
     builder.add(new TermQuery(new Term("title", "arms")), BooleanClause.Occur.SHOULD)
-        .add(new TermQuery(new Term("description", "arms")), BooleanClause.Occur.SHOULD)
-        .add(new TermQuery(new Term("subject", "arms")), BooleanClause.Occur.SHOULD);
+            .add(new TermQuery(new Term("description", "arms")), BooleanClause.Occur.SHOULD)
+            .add(new TermQuery(new Term("subject", "arms")), BooleanClause.Occur.SHOULD);
 
         /* creating a new searcher */
     searcher = new IndexSearcher(DirectoryReader.open(writer, false));

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/test/termexpansion/LabelbasedTermExpansionTest.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/test/termexpansion/LabelbasedTermExpansionTest.java
@@ -61,16 +61,16 @@ public class LabelbasedTermExpansionTest extends AbstractTermExpansionTest {
         /* defining the document to be indexed */
     Document doc = new Document();
     doc.add(new Field("title", "Spearhead",
-        TextField.TYPE_STORED));
+            TextField.TYPE_STORED));
     doc.add(new Field(
-        "description",
-        "Roman iron spearhead. The spearhead was attached to one end of a wooden shaft..."
-            + "The spear was mainly a thrusting weapon, but could also be thrown. "
-            + "It was the principal weapon of the auxiliary soldier... "
-            + "(second - fourth century, Arbeia Roman Fort).",
-        TextField.TYPE_NOT_STORED));
+            "description",
+            "Roman iron spearhead. The spearhead was attached to one end of a wooden shaft..."
+                    + "The spear was mainly a thrusting weapon, but could also be thrown. "
+                    + "It was the principal weapon of the auxiliary soldier... "
+                    + "(second - fourth century, Arbeia Roman Fort).",
+            TextField.TYPE_NOT_STORED));
     doc.add(new Field("subject", "weapons",
-        TextField.TYPE_NOT_STORED));
+            TextField.TYPE_NOT_STORED));
 
         /* setting up the SKOS analyzer */
     String skosFile = "src/test/resources/skos_samples/ukat_examples.n3";
@@ -78,7 +78,7 @@ public class LabelbasedTermExpansionTest extends AbstractTermExpansionTest {
 
         /* ExpansionType.URI->the field to be analyzed (expanded) contains URIs */
     Analyzer skosAnalyzer = new SKOSAnalyzer(indexPath, skosFile,
-        ExpansionType.LABEL);
+            ExpansionType.LABEL);
 
         /* Define different analyzers for different fields */
     Map<String, Analyzer> analyzerPerField = new HashMap<>();
@@ -94,8 +94,8 @@ public class LabelbasedTermExpansionTest extends AbstractTermExpansionTest {
         /* defining a query that searches over all fields */
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
     builder.add(new TermQuery(new Term("title", "arms")), BooleanClause.Occur.SHOULD)
-        .add(new TermQuery(new Term("description", "arms")), BooleanClause.Occur.SHOULD)
-        .add(new TermQuery(new Term("subject", "arms")), BooleanClause.Occur.SHOULD);
+            .add(new TermQuery(new Term("description", "arms")), BooleanClause.Occur.SHOULD)
+            .add(new TermQuery(new Term("subject", "arms")), BooleanClause.Occur.SHOULD);
 
         /* creating a new searcher */
     searcher = new IndexSearcher(DirectoryReader.open(writer, false));

--- a/src/test/java/at/ac/univie/mminf/luceneSKOS/test/termexpansion/URIbasedTermExpansionTest.java
+++ b/src/test/java/at/ac/univie/mminf/luceneSKOS/test/termexpansion/URIbasedTermExpansionTest.java
@@ -45,71 +45,71 @@ import static org.junit.Assert.assertEquals;
  */
 public class URIbasedTermExpansionTest extends AbstractTermExpansionTest {
 
-  /**
-   * This test indexes a sample metadata record (=lucene document) having a
-   * "title", "description", and "subject" field, which is semantically
-   * enriched by a URI pointing to a SKOS concept "weapons".
-   * <p/>
-   * A search for "arms" returns that record as a result because "arms" is
-   * defined as an alternative label (altLabel) for the concept "weapons".
-   *
-   * @throws IOException
-   */
-  @Test
-  public void uriBasedTermExpansion() throws IOException {
-
-        /* defining the document to be indexed */
-    Document doc = new Document();
-    doc.add(new Field("title", "Spearhead", TextField.TYPE_STORED));
-    doc.add(new Field("description",
-        "Roman iron spearhead. The spearhead was attached to one end of a wooden shaft..."
-            + "The spear was mainly a thrusting weapon, but could also be thrown. "
-            + "It was the principal weapon of the auxiliary soldier... "
-            + "(second - fourth century, Arbeia Roman Fort).",
-        TextField.TYPE_NOT_STORED));
-    doc.add(new Field("subject",
-        "http://www.ukat.org.uk/thesaurus/concept/859",
-        TextField.TYPE_NOT_STORED));
-
-        /* setting up the SKOS analyzer */
-    String skosFile = "src/test/resources/skos_samples/ukat_examples.n3";
-    String indexPath = "build/";
-
-        /* ExpansionType.URI->the field to be analyzed (expanded) contains URIs */
-    Analyzer skosAnalyzer = new SKOSAnalyzer(indexPath, skosFile, ExpansionType.URI);
-
-        /* Define different analyzers for different fields */
-    Map<String, Analyzer> analyzerPerField = new HashMap<>();
-    analyzerPerField.put("subject", skosAnalyzer);
-    PerFieldAnalyzerWrapper indexAnalyzer = new PerFieldAnalyzerWrapper(new SimpleAnalyzer(), analyzerPerField);
-
-        /* setting up a writer with a default (simple) analyzer */
-    writer = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(indexAnalyzer));
-
-        /* adding the document to the index */
-    writer.addDocument(doc);
-
-        /* defining a query that searches over all fields */
-    BooleanQuery.Builder builder = new BooleanQuery.Builder();
-    builder.add(new TermQuery(new Term("title", "arms")), BooleanClause.Occur.SHOULD)
-        .add(new TermQuery(new Term("description", "arms")), BooleanClause.Occur.SHOULD)
-        .add(new TermQuery(new Term("subject", "arms")), BooleanClause.Occur.SHOULD);
-
-        /* creating a new searcher */
-    searcher = new IndexSearcher(DirectoryReader.open(writer, false));
-
-    TopDocs results = searcher.search(builder.build(), 10);
-
-        /* the document matches because "arms" is among the expanded terms */
-    assertEquals(1, results.totalHits);
-
-        /* defining a query that searches for a broader concept */
-    Query query = new TermQuery(new Term("subject", "military equipment"));
-
-    results = searcher.search(query, 10);
-
-        /* ... also returns the document as result */
-    assertEquals(1, results.totalHits);
-
-  }
+    /**
+     * This test indexes a sample metadata record (=lucene document) having a
+     * "title", "description", and "subject" field, which is semantically
+     * enriched by a URI pointing to a SKOS concept "weapons".
+     * <p/>
+     * A search for "arms" returns that record as a result because "arms" is
+     * defined as an alternative label (altLabel) for the concept "weapons".
+     *
+     * @throws IOException
+     */
+    @Test
+    public void uriBasedTermExpansion() throws IOException {
+    
+            /* defining the document to be indexed */
+        Document doc = new Document();
+        doc.add(new Field("title", "Spearhead", TextField.TYPE_STORED));
+        doc.add(new Field("description",
+                "Roman iron spearhead. The spearhead was attached to one end of a wooden shaft..."
+                        + "The spear was mainly a thrusting weapon, but could also be thrown. "
+                        + "It was the principal weapon of the auxiliary soldier... "
+                        + "(second - fourth century, Arbeia Roman Fort).",
+                TextField.TYPE_NOT_STORED));
+        doc.add(new Field("subject",
+                "http://www.ukat.org.uk/thesaurus/concept/859",
+                TextField.TYPE_NOT_STORED));
+    
+            /* setting up the SKOS analyzer */
+        String skosFile = "src/test/resources/skos_samples/ukat_examples.n3";
+        String indexPath = "build/";
+    
+            /* ExpansionType.URI->the field to be analyzed (expanded) contains URIs */
+        Analyzer skosAnalyzer = new SKOSAnalyzer(indexPath, skosFile, ExpansionType.URI);
+    
+            /* Define different analyzers for different fields */
+        Map<String, Analyzer> analyzerPerField = new HashMap<>();
+        analyzerPerField.put("subject", skosAnalyzer);
+        PerFieldAnalyzerWrapper indexAnalyzer = new PerFieldAnalyzerWrapper(new SimpleAnalyzer(), analyzerPerField);
+    
+            /* setting up a writer with a default (simple) analyzer */
+        writer = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(indexAnalyzer));
+    
+            /* adding the document to the index */
+        writer.addDocument(doc);
+    
+            /* defining a query that searches over all fields */
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(new TermQuery(new Term("title", "arms")), BooleanClause.Occur.SHOULD)
+                .add(new TermQuery(new Term("description", "arms")), BooleanClause.Occur.SHOULD)
+                .add(new TermQuery(new Term("subject", "arms")), BooleanClause.Occur.SHOULD);
+    
+            /* creating a new searcher */
+        searcher = new IndexSearcher(DirectoryReader.open(writer, false));
+    
+        TopDocs results = searcher.search(builder.build(), 10);
+    
+            /* the document matches because "arms" is among the expanded terms */
+        assertEquals(1, results.totalHits);
+    
+            /* defining a query that searches for a broader concept */
+        Query query = new TermQuery(new Term("subject", "military equipment"));
+    
+        results = searcher.search(query, 10);
+    
+            /* ... also returns the document as result */
+        assertEquals(1, results.totalHits);
+    
+    }
 }


### PR DESCRIPTION
Some updates of the module. I had to make some updates to avoid some unexpected behaviour of the module in my project (repetition of the same concept in the results, offsets of the associated terms found in the SKOS resource  not in relation with the original tokens..). Here is the list of may updates:

- Fix error when passing the "indexPath" parameter in the filter factory.
- The skos file path to load must be converted into URI in order to avoid the error Code 11 "LOWERCASE_PREFERRED in SCHEME" under Windows.
- Profiles settings in the pom.xml for the artifact deployment.
- Modifying the SKOSEngine interface to return Collections instead of lists, in order to replace the returned list of concepts by a set of concepts (avoid concept repetitions).
- Adding the search of the related terms when searching with labels.
- In the TokenFilters: updating the offset attribute of the expanded terms to be the same that the original expression, in order to have a correct highlighting.